### PR TITLE
Enable scrolling when navigating with keyboard.

### DIFF
--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -208,6 +208,110 @@
         expect(comboBox.value).to.equal('baz');
       });
     });
+
+    // TODO: these tests are here to prevent possible regressions with using
+    // the internal properties of iron-list. These can be removed after this
+    // logic no longer is implemented in vaadin-combo-box.
+    describe('sanity checks for calculating visible item counts', function() {
+      it('should calculate items correctly when all items are visible', function(done) {
+        comboBox.items = ['foo', 'bar', 'baz', 'qux'];
+        comboBox.open();
+
+        asyncDone(function() {
+          expect(comboBox._visibleItemsCount()).to.eql(4);
+          expect(comboBox._lastVisibleIndex()).to.eql(3);
+        }, done, 100);
+      });
+
+      it('should calculate items correctly when some items are hidden', function(done) {
+        var items = [];
+        for (var i = 0; i < 100; i++) {
+          items.push(i.toString());
+        }
+
+        comboBox.items = items;
+        comboBox.open();
+
+        asyncDone(function() {
+          expect(comboBox._lastVisibleIndex()).to.eql(comboBox._visibleItemsCount() - 1);
+        }, done, 100);
+      });
+    });
+
+    describe('scrolling items', function() {
+      var selector;
+
+      beforeEach(function(done) {
+        var items = [];
+
+        for (var i = 0; i < 100; i++) {
+          items.push(i.toString());
+        }
+
+        comboBox.items = items;
+        comboBox.open();
+        selector = comboBox.$.selector;
+
+        Polymer.Base.async(done, 100);
+      });
+
+      it('should scroll down after reaching the last visible item', function() {
+        comboBox._focusedIndex = comboBox._visibleItemsCount() - 1;
+        expect(selector.firstVisibleIndex).to.eql(0);
+
+        arrowDown();
+
+        expect(selector.firstVisibleIndex).to.eql(1);
+      });
+
+      it('should scroll up after reaching the first visible item', function() {
+        comboBox._focusedIndex = 1;
+        selector.scrollToIndex(1);
+        expect(selector.firstVisibleIndex).to.eql(1);
+
+        arrowUp();
+
+        expect(selector.firstVisibleIndex).to.eql(0);
+      });
+
+      it('should scroll to first visible when navigating down above viewport', function() {
+        comboBox._focusedIndex = 5;
+        selector.scrollToIndex(50);
+
+        arrowDown();
+
+        expect(selector.firstVisibleIndex).to.eql(6);
+      });
+
+      it('should scroll to first visible when navigating up above viewport', function() {
+        comboBox._focusedIndex = 5;
+        selector.scrollToIndex(50);
+
+        arrowUp();
+
+        expect(selector.firstVisibleIndex).to.eql(4);
+      });
+
+      it('should scroll to last visible when navigating up below viewport', function() {
+        comboBox._focusedIndex = 50;
+        selector.scrollToIndex(0);
+        expect(selector.firstVisibleIndex).to.eql(0);
+
+        arrowUp();
+
+        expect(selector.firstVisibleIndex).to.eql(49 - comboBox._visibleItemsCount() + 1);
+      });
+
+      it('should scroll to last visible when navigating down below viewport', function() {
+        comboBox._focusedIndex = 50;
+        selector.scrollToIndex(0);
+        expect(selector.firstVisibleIndex).to.eql(0);
+
+        arrowDown();
+
+        expect(selector.firstVisibleIndex).to.eql(51 - comboBox._visibleItemsCount() + 1);
+      });
+    });
   });
 </script>
 

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -230,6 +230,7 @@
         }
 
         comboBox.items = items;
+
         comboBox.open();
 
         asyncDone(function() {
@@ -310,6 +311,29 @@
         arrowDown();
 
         expect(selector.firstVisibleIndex).to.eql(51 - comboBox._visibleItemsCount() + 1);
+      });
+
+      it('should scroll to start if no items focused when opening overlay', function(done) {
+          selector.scrollToIndex(50);
+          comboBox.close();
+
+          comboBox.open();
+
+          asyncDone(function() {
+            expect(selector.firstVisibleIndex).to.eql(0);
+          }, done, 100);
+      });
+
+      it('should scroll to focused item when opening overlay', function(done) {
+        selector.scrollToIndex(0);
+        comboBox.close();
+        comboBox.value = '50';
+
+        comboBox.open();
+
+        asyncDone(function() {
+          expect(selector.firstVisibleIndex).to.eql(50 - comboBox._visibleItemsCount() + 1);
+        }, done, 100);
       });
     });
   });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -332,7 +332,7 @@
         comboBox.open();
 
         asyncDone(function() {
-          expect(selector.firstVisibleIndex).to.eql(50 - comboBox._visibleItemsCount() + 1);
+          expect(selector.firstVisibleIndex).to.be.within(50 - comboBox._visibleItemsCount(), 50);
         }, done, 100);
       });
     });

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -144,8 +144,27 @@
       */
       ios: {
         value: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
-      }
+      },
 
+      /**
+        * Returns the scrollable element.
+        *
+        * @property scroller
+        * @type Object
+        */
+      scroller: {
+        type: Object,
+        computed: '_scroller(fullScreen)'
+      }
+    },
+
+    _scroller: function(fullScreen) {
+      // with touch scrolling, default scroller element needs to be used.
+      if (!this.fullScreen) {
+        // For <iron-list> scrollToIndex() and _viewportSize to work in IE11,
+        // we need to use #dropdownContent as scroller element.
+        return this.$.dropdownContent;
+      }
     },
 
     _computePositionTarget: function(fullScreen) {

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -23,6 +23,7 @@
 
     .dropdown-content {
       width: 100vw;
+      transform: translate3d(0, 0, 0);
       @apply(--dropdown-content);
     }
 
@@ -140,8 +141,8 @@
       },
 
       /**
-      * True if running on an iOS device
-      */
+       * True if running on an iOS device
+       */
       ios: {
         value: /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream
       },

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -319,7 +319,7 @@
 
     _focusedIndexChanged: function(index, prevIndex) {
       if (index >= 0) {
-        if (index < this.$.selector.firstVisibleIndex) {
+        if (index <= this.$.selector.firstVisibleIndex) {
           this.$.selector.scrollToIndex(index);
         } else if (index > this._lastVisibleIndex()) {
           this.$.selector.scrollToIndex(index - this._visibleItemsCount() + 1);

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -320,13 +320,17 @@
       this.close();
     },
 
-    _focusedIndexChanged: function(index, prevIndex) {
+    _focusedIndexChanged: function(index) {
       if (index >= 0) {
-        if (index <= this.$.selector.firstVisibleIndex) {
-          this.$.selector.scrollToIndex(index);
-        } else if (index > this._lastVisibleIndex()) {
-          this.$.selector.scrollToIndex(index - this._visibleItemsCount() + 1);
-        }
+        this._scrollIntoView(index);
+      }
+    },
+
+    _scrollIntoView: function(index) {
+      if (index <= this.$.selector.firstVisibleIndex) {
+        this.$.selector.scrollToIndex(index);
+      } else if (index > this._lastVisibleIndex()) {
+        this.$.selector.scrollToIndex(index - this._visibleItemsCount() + 1);
       }
     },
 
@@ -439,6 +443,12 @@
     _openedChanged: function() {
       if (this.opened) {
         this._setItems(this.items);
+
+        // TODO: needs to be async because iron-overlay-opened hasn't necessarily been fired yet.
+        this.async(function() {
+          this._scrollIntoView(this._focusedIndex);
+        }, 1);
+
       } else {
         this.$.input.bindValue = this.value;
         this.$.fullScreenInput.bindValue = this.value;

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -61,6 +61,9 @@
       cursor: pointer;
       padding: 13px 16px;
       color: var(--primary-text-color);
+      white-space: nowrap;
+      overflow: hidden;
+      text-overflow: ellipsis;
     }
 
     #overlay:not([full-screen]) .item:hover,

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -236,7 +236,8 @@
 
       _focusedIndex: {
         type: Number,
-        value: -1
+        value: -1,
+        observer: '_focusedIndexChanged'
       }
     },
 
@@ -314,6 +315,34 @@
 
     _onEscape: function() {
       this.close();
+    },
+
+    _focusedIndexChanged: function(index, prevIndex) {
+      if (index >= 0) {
+        if (index < this.$.selector.firstVisibleIndex) {
+          this.$.selector.scrollToIndex(index);
+        } else if (index > this._lastVisibleIndex()) {
+          this.$.selector.scrollToIndex(index - this._visibleItemsCount() + 1);
+        }
+      }
+    },
+
+    // TODO: Try to get this logic adopted into iron-list.
+    _visibleItemsCount: function() {
+      var firstItemIndex = this.$.selector._physicalStart;
+      var firstItemHeight = this.$.selector._physicalSizes[firstItemIndex];
+
+      if (firstItemHeight) {
+        var visibleItems = this.$.selector._viewportSize / firstItemHeight;
+        return Math.floor(visibleItems);
+      }
+    },
+
+    // TODO: Try to get this logic adopted into iron-list.
+    _lastVisibleIndex: function() {
+      if (this._visibleItemsCount()) {
+        return this.$.selector.firstVisibleIndex + this._visibleItemsCount() - 1;
+      }
     },
 
     /**


### PR DESCRIPTION
Uses logic adopted from iron-list to determine the number of
visible items and the index of the last visible item to trigger
scrolling only when navigating out of the viewport.

Fixes #45

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/66)
<!-- Reviewable:end -->
