### PR TITLE
Add example for setting items.

### DIFF
--- a/demo/index.html
+++ b/demo/index.html
@@ -26,6 +26,21 @@
     <table-of-contents select="h3" class="toc"></table-of-contents>
   </section>
 
+  <section>
+    <h3>Setting items</h3>
+    <p>The data displayed by <code>vaadin-combo-box</code> can be set and accessed using the
+    <code>items</code> property. Only an array of <code>String</code> values is currently supported.
+
+    <code-example source>
+      <vaadin-combo-box demo items='["foo"]'></vaadin-combo-box>
+
+      <code demo-var="combobox">
+        var combobox = combobox || document.querySelector('vaadin-combo-box');
+        // items can be also accessed directly
+        // combobox.items = ['foo', 'bar', 'baz'];
+      </code>
+    </code-example>
+  </section>
 
   <section>
     <h3>Opening and closing</h3>


### PR DESCRIPTION
Added this example to have a place to tell the user to only use String values. iron-list doesn’t work properly with numbers or booleans.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/68)
<!-- Reviewable:end -->
