### PR TITLE
Fix #48 items text overlap above the underline in Safari

### DIFF
--- a/test/adaptive-overlay.html
+++ b/test/adaptive-overlay.html
@@ -110,6 +110,31 @@
           expect(viewportInfo.content).not.to.equal(overlay._viewportInfo._fullScreenContent);
         });
 
+        it('should have device pixel accurate vertical coordinate for dropdown', function(done) {
+          overlay.close();
+
+          // Give offset by irrational number of pixels, that never results
+          // into interger device pixel-accurate value when rendering
+          overlay.parentElement.style.marginTop = Math.E + 'px';
+
+          overlay.parentElement.style.float = 'left'; // disables margins collapsing
+
+          overlay.open();
+
+          Polymer.Base.async(function() {
+            var target = overlay.$.dropdown._verticalAlignTargetValue;
+
+            // When multiplied by `devicePixelRatio`, target should be integer
+            expect(target * (window.devicePixelRatio || 1) % 1).to.be.equal(0);
+
+            // Cleanup the inline styles
+            overlay.parentElement.style.removeProperty('margin-top');
+            overlay.parentElement.style.removeProperty('float');
+
+            done();
+          });
+        });
+
       });
 
     });

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -52,7 +52,7 @@
       with-backdrop=[[fullScreen]]
       position-target=[[positionTarget]]
       vertical-align=[[_verticalAlign]]
-      vertical-offset=[[_computeVerticalOffset(opened,positionTarget,fullScreen)]]
+      vertical-offset=[[_computeVerticalOffset(opened,positionTarget,fullScreen,_verticalAlign)]]
       on-tap="_tapped"
       on-iron-overlay-closed="_closed"
       on-iron-overlay-opened="_opened"
@@ -172,8 +172,45 @@
       return fullScreen ? document.documentElement : this.domHost || this.parentElement;
     },
 
-    _computeVerticalOffset: function(opened, positionTarget, fullScreen) {
-      return !fullScreen && positionTarget ? positionTarget.clientHeight : 0;
+    // Computes the vertical coordinate of positionTarget, to be used for
+    // the dropdown alignment. Made after <iron-dropdown/>’s computation in
+    // _verticalAlignTargetValue property getter.
+    _computeVerticalAlignTargetValue: function(positionTarget, _verticalAlign) {
+      var target;
+      var positionRect = positionTarget.getBoundingClientRect();
+
+      if (_verticalAlign === 'bottom') {
+        target = document.documentElement.clientHeight - positionRect.bottom;
+      } else {
+        target = positionRect.top;
+      }
+
+      return target;
+    },
+
+    _computeVerticalOffset: function(opened, positionTarget, fullScreen, _verticalAlign) {
+      var verticalOffset = 0;
+
+      if (!fullScreen && positionTarget) {
+        verticalOffset = positionTarget.clientHeight;
+
+        // In Safari, when dropdown is positioned on non-integer vertical
+        // coordinate, the items text is sometimes rendered 1 device pixel line
+        // outside the dropdown during vertical scrolling.
+        //
+        // We predict the vertical coordinate of the dropdown and shift its
+        // offset by a small error-correcting value, to make the vertical
+        // coordinate of the dropdown an integer number of device pixels.
+
+        var target = this._computeVerticalAlignTargetValue(positionTarget, _verticalAlign);
+        // We can't use the <iron-dropdown/>’s _verticalAlignTargetValue
+        // property getter instead, because it depends on the verticalOffset.
+
+        var devicePixelRatio = window.devicePixelRatio || 1;
+        verticalOffset += Math.round(target * devicePixelRatio) / devicePixelRatio - target;
+      }
+
+      return verticalOffset;
     },
 
     _verticalAlignChanged: function() {


### PR DESCRIPTION
This fix introduces a small correction for the overlay's dropdown vertical offset. The offset is shifted by a small value, to make the vertical coordinate of the dropdown equal interger number of device pixels. This resolves rounding problems with Safari rendering engine, making the combo-box items text to always render inside the dropdown, behind the underline.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/77)
<!-- Reviewable:end -->
