### PR TITLE
Fix input container height for iOS8 Safari.

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -115,6 +115,7 @@
     #overlay[full-screen] paper-input-container {
       @apply(--shadow-elevation-2dp);
       flex-shrink: 0;
+      -webkit-flex-shrink: 0;
       padding: 0;
     }
 


### PR DESCRIPTION
Related with #35

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/79)
<!-- Reviewable:end -->
