### PR TITLE
Replace async calls when opening and closing the dropdown with a wait

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -42,6 +42,7 @@
     "test-fixture": "polymerelements/test-fixture#^1.0.0",
     "iron-test-helpers": "polymerelements/iron-test-helpers#^1.0.0",
     "iron-component-page": "polymerelements/iron-component-page#~1.1.0",
-    "elements-demo-resources": "vaadin/elements-demo-resources#master"
+    "elements-demo-resources": "vaadin/elements-demo-resources#master",
+    "promise-polyfill": "polymerlabs/promise-polyfill#~1.0.0"
   }
 }

--- a/test/aria.html
+++ b/test/aria.html
@@ -9,6 +9,7 @@
   <script src='../bower_components/test-fixture/test-fixture-mocha.js'></script>
 
   <link rel='import' href='common.html'>
+  <script src="../bower_components/promise-polyfill/Promise.js"></script>
   <script src='common.js'></script>
 </head>
 
@@ -68,6 +69,8 @@
     describe('when overlay opens or close', function() {
       beforeEach(function() {
         arrowDown();
+
+        return waitUntilOpen();
       });
 
       it('should set aria-expanded attribute when opened', function() {
@@ -76,13 +79,18 @@
 
       it('should unset aria-expanded attribute when closed', function() {
         esc();
-        expect(getInput().getAttribute('aria-expanded')).to.equal('false');
+
+        return waitUntilClosed().then(function() {
+          expect(getInput().getAttribute('aria-expanded')).to.equal('false');
+        });
       });
     });
 
     describe('navigating the items', function() {
       beforeEach(function() {
         arrowDown();
+
+        return waitUntilOpen();
       });
 
       it('should set selection aria attributes when focusing an item', function(done) {

--- a/test/common.js
+++ b/test/common.js
@@ -39,6 +39,31 @@ var asyncDone = function(cb, done, timeout) {
   }, timeout || 1);
 };
 
+function _waitForOpened(open) {
+  if (!Promise) {
+    Promise = MakePromise(Polymer.Base.async);
+  }
+
+  return new Promise(function(resolve, reject) {
+    var handle = setInterval(function() {
+      var combobox = document.querySelector('vaadin-combo-box');
+
+      if (combobox.opened == open && !combobox.$.overlay.$.dropdown._openChangedAsync) {
+        clearInterval(handle);
+        resolve();
+      }
+    }, 10);
+  });
+}
+
+var waitForOpen = function() {
+  return _waitForOpened(true);
+};
+
+var waitForClosed = function() {
+  return _waitForOpened(false);
+};
+
 var getItemArray = function(length) {
   return new Array(length).join().split(',')
     .map(function(item, index) {

--- a/test/common.js
+++ b/test/common.js
@@ -39,9 +39,9 @@ var asyncDone = function(cb, done, timeout) {
   }, timeout || 1);
 };
 
-function _waitForOpened(open) {
-  if (!Promise) {
-    Promise = MakePromise(Polymer.Base.async);
+function _waitUntilOpened(open) {
+  if (!window.Promise) {
+    window.Promise = MakePromise(Polymer.Base.async);
   }
 
   return new Promise(function(resolve, reject) {
@@ -56,12 +56,12 @@ function _waitForOpened(open) {
   });
 }
 
-var waitForOpen = function() {
-  return _waitForOpened(true);
+var waitUntilOpen = function() {
+  return _waitUntilOpened(true);
 };
 
-var waitForClosed = function() {
-  return _waitForOpened(false);
+var waitUntilClosed = function() {
+  return _waitUntilOpened(false);
 };
 
 var getItemArray = function(length) {

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -63,7 +63,7 @@
       it('should open the overlay with arrow down and not focus any item', function() {
         arrowDown();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(comboBox.opened).to.equal(true);
           expect(getFocusedIndex()).to.equal(-1);
         });
@@ -72,7 +72,7 @@
       it('should open the overlay with arrow up and not focus any item', function() {
         arrowUp();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(comboBox.opened).to.equal(true);
           expect(getFocusedIndex()).to.equal(-1);
         });
@@ -83,7 +83,7 @@
 
         arrowDown();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(getFocusedIndex()).to.equal(0);
         });
       });
@@ -93,7 +93,7 @@
       beforeEach(function() {
         arrowDown();
 
-        return waitForOpen();
+        return waitUntilOpen();
       });
 
       it('should focus on the first item with arrow down', function() {
@@ -154,7 +154,7 @@
         comboBox.value = 'bar';
         arrowDown();
 
-        return waitForOpen();
+        return waitUntilOpen();
       });
 
       it('should select focused item with enter', function() {
@@ -190,7 +190,7 @@
       it('should close the overlay with enter', function() {
         enter();
 
-        return waitForClosed(function() {
+        return waitUntilClosed(function() {
           expect(comboBox.opened).to.equal(false);
         });
       });
@@ -198,7 +198,7 @@
       it('should close the overlay with escape', function() {
         esc();
 
-        return waitForClosed(function() {
+        return waitUntilClosed(function() {
           expect(comboBox.opened).to.equal(false);
         });
       });
@@ -208,7 +208,7 @@
 
         esc();
 
-        return waitForClosed(function() {
+        return waitUntilClosed(function() {
           expect(comboBox.value).to.equal('bar');
         });
       });
@@ -218,7 +218,7 @@
 
         enter();
 
-        return waitForClosed(function() {
+        return waitUntilClosed(function() {
           expect(comboBox.value).to.equal('baz');
         });
       });
@@ -232,7 +232,7 @@
         comboBox.items = ['foo', 'bar', 'baz', 'qux'];
         comboBox.open();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(comboBox._visibleItemsCount()).to.eql(4);
           expect(comboBox._lastVisibleIndex()).to.eql(3);
         });
@@ -249,7 +249,7 @@
 
         comboBox.open();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(comboBox._lastVisibleIndex()).to.eql(comboBox._visibleItemsCount() - 1);
         });
       });
@@ -269,7 +269,7 @@
         comboBox.open();
         selector = comboBox.$.selector;
 
-        return waitForOpen();
+        return waitUntilOpen();
       });
 
       it('should scroll down after reaching the last visible item', function() {
@@ -335,7 +335,7 @@
 
         comboBox.open();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(selector.firstVisibleIndex).to.eql(0);
         });
       });
@@ -347,7 +347,7 @@
 
         comboBox.open();
 
-        return waitForOpen().then(function() {
+        return waitUntilOpen().then(function() {
           expect(selector.firstVisibleIndex).to.be.within(50 - comboBox._visibleItemsCount(), 50);
         });
       });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -9,6 +9,7 @@
   <script src='../bower_components/test-fixture/test-fixture-mocha.js'></script>
 
   <link rel='import' href='common.html'>
+  <script src="../bower_components/promise-polyfill/Promise.js"></script>
   <script src='common.js'></script>
 </head>
 
@@ -62,17 +63,19 @@
       it('should open the overlay with arrow down and not focus any item', function() {
         arrowDown();
 
-        expect(comboBox.opened).to.equal(true);
-
-        expect(getFocusedIndex()).to.equal(-1);
+        return waitForOpen().then(function() {
+          expect(comboBox.opened).to.equal(true);
+          expect(getFocusedIndex()).to.equal(-1);
+        });
       });
 
       it('should open the overlay with arrow up and not focus any item', function() {
         arrowUp();
 
-        expect(comboBox.opened).to.equal(true);
-
-        expect(getFocusedIndex()).to.equal(-1);
+        return waitForOpen().then(function() {
+          expect(comboBox.opened).to.equal(true);
+          expect(getFocusedIndex()).to.equal(-1);
+        });
       });
 
       it('should have focus on the selected item after opened', function() {
@@ -80,13 +83,17 @@
 
         arrowDown();
 
-        expect(getFocusedIndex()).to.equal(0);
+        return waitForOpen().then(function() {
+          expect(getFocusedIndex()).to.equal(0);
+        });
       });
     });
 
     describe('navigating the items after overlay opened', function() {
       beforeEach(function() {
         arrowDown();
+
+        return waitForOpen();
       });
 
       it('should focus on the first item with arrow down', function() {
@@ -146,6 +153,8 @@
       beforeEach(function() {
         comboBox.value = 'bar';
         arrowDown();
+
+        return waitForOpen();
       });
 
       it('should select focused item with enter', function() {
@@ -181,15 +190,17 @@
       it('should close the overlay with enter', function() {
         enter();
 
-        expect(comboBox.opened).to.equal(false);
+        return waitForClosed(function() {
+          expect(comboBox.opened).to.equal(false);
+        });
       });
 
-      it('should close the overlay with escape', function(done) {
+      it('should close the overlay with escape', function() {
         esc();
 
-        asyncDone(function() {
+        return waitForClosed(function() {
           expect(comboBox.opened).to.equal(false);
-        }, done, 100);
+        });
       });
 
       it('should cancel typing with escape', function() {
@@ -197,7 +208,9 @@
 
         esc();
 
-        expect(comboBox.value).to.equal('bar');
+        return waitForClosed(function() {
+          expect(comboBox.value).to.equal('bar');
+        });
       });
 
       it('should select typed item', function() {
@@ -205,7 +218,9 @@
 
         enter();
 
-        expect(comboBox.value).to.equal('baz');
+        return waitForClosed(function() {
+          expect(comboBox.value).to.equal('baz');
+        });
       });
     });
 
@@ -213,17 +228,18 @@
     // the internal properties of iron-list. These can be removed after this
     // logic no longer is implemented in vaadin-combo-box.
     describe('sanity checks for calculating visible item counts', function() {
-      it('should calculate items correctly when all items are visible', function(done) {
+      it('should calculate items correctly when all items are visible', function() {
         comboBox.items = ['foo', 'bar', 'baz', 'qux'];
         comboBox.open();
 
-        asyncDone(function() {
+        return waitForOpen().then(function() {
           expect(comboBox._visibleItemsCount()).to.eql(4);
           expect(comboBox._lastVisibleIndex()).to.eql(3);
-        }, done, 100);
+        });
+
       });
 
-      it('should calculate items correctly when some items are hidden', function(done) {
+      it('should calculate items correctly when some items are hidden', function() {
         var items = [];
         for (var i = 0; i < 100; i++) {
           items.push(i.toString());
@@ -233,16 +249,16 @@
 
         comboBox.open();
 
-        asyncDone(function() {
+        return waitForOpen().then(function() {
           expect(comboBox._lastVisibleIndex()).to.eql(comboBox._visibleItemsCount() - 1);
-        }, done, 100);
+        });
       });
     });
 
     describe('scrolling items', function() {
       var selector;
 
-      beforeEach(function(done) {
+      beforeEach(function() {
         var items = [];
 
         for (var i = 0; i < 100; i++) {
@@ -253,7 +269,7 @@
         comboBox.open();
         selector = comboBox.$.selector;
 
-        Polymer.Base.async(done, 100);
+        return waitForOpen();
       });
 
       it('should scroll down after reaching the last visible item', function() {
@@ -313,27 +329,27 @@
         expect(selector.firstVisibleIndex).to.eql(51 - comboBox._visibleItemsCount() + 1);
       });
 
-      it('should scroll to start if no items focused when opening overlay', function(done) {
-          selector.scrollToIndex(50);
-          comboBox.close();
+      it('should scroll to start if no items focused when opening overlay', function() {
+        selector.scrollToIndex(50);
+        comboBox.close();
 
-          comboBox.open();
+        comboBox.open();
 
-          asyncDone(function() {
-            expect(selector.firstVisibleIndex).to.eql(0);
-          }, done, 100);
+        return waitForOpen().then(function() {
+          expect(selector.firstVisibleIndex).to.eql(0);
+        });
       });
 
-      it('should scroll to focused item when opening overlay', function(done) {
+      it('should scroll to focused item when opening overlay', function() {
         selector.scrollToIndex(0);
         comboBox.close();
         comboBox.value = '50';
 
         comboBox.open();
 
-        asyncDone(function() {
+        return waitForOpen().then(function() {
           expect(selector.firstVisibleIndex).to.be.within(50 - comboBox._visibleItemsCount(), 50);
-        }, done, 100);
+        });
       });
     });
   });

--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -9,6 +9,7 @@
   <script src='../bower_components/test-fixture/test-fixture-mocha.js'></script>
 
   <link rel='import' href='common.html'>
+  <script src="../bower_components/promise-polyfill/Promise.js"></script>
   <script src="common.js"></script>
 
 </head>
@@ -82,32 +83,32 @@
     });
 
     describeSkipIf(fullScreen, 'overlay position', function() {
-      it('should match the input container width', function(done) {
+      it('should match the input container width', function() {
         openComboboxTop();
 
-        asyncDone(function() {
-          expect(dropContentRect().width).to.equal(100);
-          comboBox.close();
-          asyncDone(function() {
+        return waitUntilOpen()
+          .then(function() {
+            expect(dropContentRect().width).to.equal(100);
+            comboBox.close();
+          })
+          .then(waitUntilClosed)
+          .then(function() {
             expect(dropContentRect().width).to.equal(0);
-          }, done);
+          });
+      });
+
+      it('should be below the input box if there is enough room under it', function() {
+        openComboboxTop();
+
+        return waitUntilOpen().then(function() {
+          expect(dropContentRect().top).to.be.above(inputContentRect().top);
         });
       });
 
-      it('should be below the input box if there is enough room under it', function(done) {
-        openComboboxTop();
-
-        asyncDone(function() {
-          expect(dropContentRect().top).to.be.above(inputContentRect().top);
-        }, done);
-      });
-
-      it('should be above the input box if there is not enough room under it', function(done) {
+      it('should be above the input box if there is not enough room under it', function() {
         openComboboxBottom();
 
-        // TODO(manolo) for some reason if we listen to iron-overlay-opened event it fires twice
-        // so we prefer a small delay here, until window.resize or animation is handled
-        asyncDone(function() {
+        return waitUntilOpen().then(function() {
           // FIXME(manolo) iron-dropdown computes wrong the max-height value for the dropdownContent
           // element, and it gives all the height that the list needs (no scroll). It only happens
           // when the popup is above the input. The bottom position of the iron-dropdown element is
@@ -117,7 +118,7 @@
           }
           // In chrome difference is around 1px in FF about 4px
           expectAlmostEqual(6, dropContentRect().bottom, inputContentRect().top);
-        }, done);
+        });
       });
 
       it('when the input position moves in the view port the overlay position should change', function(done) {

--- a/test/scrolling.html
+++ b/test/scrolling.html
@@ -9,6 +9,7 @@
   <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="common.html">
+  <script src="../bower_components/promise-polyfill/Promise.js"></script>
   <script src="common.js"></script>
 </head>
 
@@ -35,18 +36,17 @@
           input = combobox.$.fullScreenInput;
         });
 
-        it('should blur fullscreen input on scroll', function(done) {
+        it('should blur fullscreen input on scroll', function() {
           combobox.open();
-          Polymer.Base.async(function() {
+
+          return waitUntilOpen().then(function() {
             selector.fire('down');
             var focusedInput = Polymer.dom(combobox.$.overlay).querySelector('input:focus');
+
             expect(focusedInput).not.to.equal(combobox.$.fullScreenInput);
-            done();
           });
         });
-
       });
-
     });
   </script>
 

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -9,6 +9,7 @@
   <script src="../bower_components/test-fixture/test-fixture-mocha.js"></script>
 
   <link rel="import" href="common.html">
+  <script src="../bower_components/promise-polyfill/Promise.js"></script>
   <script src="common.js"></script>
 </head>
 
@@ -33,29 +34,35 @@
       it('should open on click', function() {
         combobox.$$('paper-input-container').fire('tap');
 
-        expect(combobox.opened).to.be.true;
+        return waitUntilOpen().then(function() {
+          expect(combobox.opened).to.be.true;
+        });
       });
 
       it('should open on function call', function() {
         combobox.open();
 
-        expect(combobox.opened).to.be.true;
+        return waitUntilOpen().then(function() {
+          expect(combobox.opened).to.be.true;
+        });
       });
 
       it('should not close an open popup', function() {
         combobox.open();
 
-        combobox.open();
+        return waitUntilOpen().then(function() {
+          combobox.open();
 
-        expect(combobox.opened).to.be.true;
+          expect(combobox.opened).to.be.true;
+        });
       });
 
       describeIf(fullScreen, 'fullscreen', function() {
-        beforeEach(function(done) {
+        beforeEach(function() {
           combobox.$.overlay.fullScreen = true;
           combobox.open();
 
-          Polymer.Base.async(done);
+          return waitUntilOpen();
         });
 
         it('should focus input on fullscreen dropdown open', function() {
@@ -64,22 +71,20 @@
           expect(focusedInput).to.equal(combobox.$.fullScreenInput);
         });
 
-        it('should blur input when closing', function(done) {
+        it('should blur input when closing', function() {
           combobox.close();
 
-          asyncDone(function() {
+          return waitUntilClosed().then(function() {
             var focusedInput = Polymer.dom(combobox.$.overlay).querySelector('input:focus');
 
             expect(focusedInput).to.be.undefined;
-          }, done);
+          });
         });
 
         it('should prevent focus of non-fullscreen input field', function() {
           expect(combobox.$.input.tabIndex).to.equal(-1);
         });
-
       });
-
     });
 
     describe('closing', function() {
@@ -87,40 +92,52 @@
         combobox.$.overlay.fullScreen = true;
         combobox.open();
 
-        // Fake a tap event for the #dropdownContent.
-        Polymer.Base.fire('tap', {}, {
-          bubbles: true,
-          node: combobox.$.overlay.$.dropdownContent
-        });
-
-        expect(combobox.opened).to.be.false;
+        return waitUntilOpen()
+          .then(function() {
+            // Fake a tap event for the #dropdownContent.
+            Polymer.Base.fire('tap', {}, {
+              bubbles: true,
+              node: combobox.$.overlay.$.dropdownContent
+            });
+          })
+          .then(waitUntilClosed)
+          .then(function() {
+            expect(combobox.opened).to.be.false;
+          });
       });
 
       describeIf(!fullScreen, 'on blur', function() {
-        it('should close the overlay when focus is lost', function(done) {
+        it('should close the overlay when focus is lost', function() {
           combobox.open();
-          MockInteractions.blur(combobox.$.input);
-          asyncDone(function() {
-            expect(combobox.opened).to.equal(false);
-          }, done, 100);
+
+          return waitUntilOpen()
+            .then(function() {
+              MockInteractions.blur(combobox.$.input);
+            })
+            .then(waitUntilClosed)
+            .then(function() {
+              expect(combobox.opened).to.equal(false);
+            });
         });
       });
 
       describeIf(fullScreen, 'on blur fullscreen', function() {
-        it('should close the overlay when focus is lost', function(done) {
+        it('should close the overlay when focus is lost', function() {
           // We need a dummy input as a focus target in fullscreen mode.
           var dummyInput = document.createElement('input');
           document.body.appendChild(dummyInput);
 
           combobox.open();
-          Polymer.Base.async(function() {
-            dummyInput.focus();
-          }, 50);
 
-          asyncDone(function() {
-            expect(combobox.opened).to.equal(false);
-            document.body.removeChild(dummyInput);
-          }, done, 100);
+          return waitUntilOpen()
+            .then(function() {
+              dummyInput.focus();
+            })
+            .then(waitUntilClosed)
+            .then(function() {
+              expect(combobox.opened).to.equal(false);
+              document.body.removeChild(dummyInput);
+            });
         });
       });
     });


### PR DESCRIPTION
It's not perfect, but removes lots of arbitrary timeouts we've been using and makes the tests less flaky.

Added a Promise polyfill mainly for IE 11, chose to use Promises instead of regular callbacks to make the nested waits more readable.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/82)
<!-- Reviewable:end -->
