### PR TITLE
Add a viewport threshold on full screen mode

### DIFF
--- a/test/adaptive-overlay.html
+++ b/test/adaptive-overlay.html
@@ -42,9 +42,14 @@
       describe('fullscreen', function() {
 
         beforeEach(function(done) {
-          overlay.fullScreen = true;
+          overlay.responsiveWidth = '600px';
+          overlay.forceFullScreen = true;
           overlay.open();
           Polymer.Base.async(done);
+        });
+
+        it('should open in fullscreen mode when forced', function() {
+          expect(overlay.fullScreen).to.be.true;
         });
 
         it('should have correct dimensions', function() {
@@ -89,9 +94,14 @@
       describe('non-fullscreen', function() {
 
         beforeEach(function(done) {
-          overlay.fullScreen = false;
+          overlay.responsiveWidth = '0px';
+          overlay.forceFullScreen = false;
           overlay.open();
           Polymer.Base.async(done);
+        });
+
+        it('should not open in fullscreen mode', function() {
+          expect(overlay.fullScreen).to.be.false;
         });
 
         it('should have correct target elements', function() {
@@ -140,6 +150,33 @@
           overlay.open();
         });
 
+      });
+
+    });
+
+    describe('responsiveWidth property', function() {
+      var overlay;
+
+      beforeEach(function(done) {
+        overlay = fixture('overlay').firstElementChild;
+      });
+
+      it('should open in fullscreen mode if responsiveWidth is >= viewport', function(done) {
+        overlay.responsiveWidth = window.innerWidth + 'px';
+        overlay.open();
+        Polymer.Base.async(function() {
+          expect(overlay.fullScreen).to.be.true;
+          done();
+        });
+      });
+
+      it('should open in non-fullscreen mode if responsiveWidth is < viewport', function(done) {
+        overlay.responsiveWidth = (window.innerWidth - 1) + 'px';
+        overlay.open();
+        Polymer.Base.async(function() {
+          expect(overlay.fullScreen).to.be.false;
+          done();
+        });
       });
 
     });

--- a/test/adaptive-overlay.html
+++ b/test/adaptive-overlay.html
@@ -119,10 +119,12 @@
 
           overlay.parentElement.style.float = 'left'; // disables margins collapsing
 
-          overlay.open();
+          var interval = setInterval(function() {
+            if (overlay.$.dropdown._openChangedAsync) {
+              return;
+            }
 
-          Polymer.Base.async(function() {
-            var target = overlay.$.dropdown._verticalAlignTargetValue;
+            var target = overlay.$.dropdown.getBoundingClientRect().top;
 
             // When multiplied by `devicePixelRatio`, target should be integer
             expect(target * (window.devicePixelRatio || 1) % 1).to.be.equal(0);
@@ -131,8 +133,11 @@
             overlay.parentElement.style.removeProperty('margin-top');
             overlay.parentElement.style.removeProperty('float');
 
+            clearInterval(interval);
             done();
-          });
+          }, 100);
+
+          overlay.open();
         });
 
       });

--- a/test/common.js
+++ b/test/common.js
@@ -8,6 +8,9 @@ var fullScreen = (function() {
   }
 })();
 
+// Set the test runner window width to trigger fullscreen mode
+window.parent.document.querySelector('#subsuites').style.width = fullScreen ? '500px' : '700px';
+
 var describeSkipIf = function(bool, title, callback) {
   bool = typeof bool == 'function' ? bool() : bool;
   if (bool) {

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -52,7 +52,7 @@
     [false, true].forEach(function(isFullScreen) {
       describe('setting the input field value in ' + (isFullScreen === true ? 'fullscreen' : 'desktop'), function() {
         beforeEach(function() {
-          comboBox.$.overlay.fullScreen = isFullScreen;
+          comboBox.$.overlay.forceFullScreen = isFullScreen;
         });
 
         it('should open the popup if closed', function() {

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -59,7 +59,7 @@
 
       describeIf(fullScreen, 'fullscreen', function() {
         beforeEach(function() {
-          combobox.$.overlay.fullScreen = true;
+          combobox.$.overlay.forceFullScreen = true;
           combobox.open();
 
           return waitUntilOpen();
@@ -89,7 +89,7 @@
 
     describe('closing', function() {
       it('should close fullscreen popup when tapping on modal curtain', function() {
-        combobox.$.overlay.fullScreen = true;
+        combobox.$.overlay.forceFullScreen = true;
         combobox.open();
 
         return waitUntilOpen()

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -31,7 +31,7 @@
       @apply(--dropdown-content-bottom-align);
     }
 
-    #dropdown[ios][fullscreen] {
+    #dropdown[ios] {
       position: absolute;
     }
 
@@ -85,20 +85,30 @@
       },
 
       /**
+       * The responsive break point value. If the viewport width is below,
+       * the overlay would open in full screen mode.
+       */
+      responsiveWidth: {
+        type: String,
+        value: '600px'
+      },
+
+      /**
+       * Turns on the full screen mode regardless of the viewport size.
+       */
+      forceFullScreen: {
+        type: Boolean,
+        value: false
+      },
+
+      /**
        * True if the overlay works in full screen mode (e.g. on mobile devices).
        */
       fullScreen: {
         type: Boolean,
+        readOnly: true,
         notify: true,
-        reflectToAttribute: true,
-        value: function() {
-          try {
-            document.createEvent('TouchEvent');
-            return true;
-          } catch (e) {
-            return false;
-          }
-        }
+        reflectToAttribute: true
       },
 
       /**
@@ -161,13 +171,14 @@
         */
       scroller: {
         type: Object,
-        computed: '_scroller(fullScreen)'
+        computed: '_scroller(fullScreen)',
+        observer: '_scrollerChanged'
       }
     },
 
     _scroller: function(fullScreen) {
       // with touch scrolling, default scroller element needs to be used.
-      if (!this.fullScreen) {
+      if (!fullScreen) {
         // For <iron-list> scrollToIndex() and _viewportSize to work in IE11,
         // we need to use #dropdownContent as scroller element.
         return this.$.dropdownContent;
@@ -176,6 +187,22 @@
 
     _allowOutsideScroll: function(fullScreen) {
       return !fullScreen;
+    },
+
+    _scrollerChanged: function(scroller) {
+      var list = Polymer.dom(this).querySelector('iron-list');
+
+      if (list) {
+        // Trigger detached and attached event handlers of the iron-list
+        // in order to refresh its internal _scroller property.
+        list.detached();
+        list.classList.remove('has-scroller'); // TODO: Send a PR to <iron-list/>
+        list.attached();
+      }
+    },
+
+    _computeMediaQuery: function(forceFullScreen, responsiveWidth) {
+      return forceFullScreen ? '' : '(max-width: ' + responsiveWidth + ')';
     },
 
     _computePositionTarget: function(fullScreen) {
@@ -224,9 +251,11 @@
     },
 
     _verticalAlignChanged: function() {
-      this.close();
-      this.$.dropdown.resetFit();
-      this.async(this.open);
+      if (this.opened) {
+        this.close();
+        this.$.dropdown.resetFit();
+        this.async(this.open);
+      }
     },
 
     /**
@@ -251,6 +280,13 @@
      * Open the overlay.
      */
     open: function() {
+      // Check if the overlay should be opened in full screen
+      this._setFullScreen(
+        window.matchMedia(
+          this._computeMediaQuery(this.forceFullScreen, this.responsiveWidth)
+        ).matches
+      );
+
       this.$.dropdown.open();
     },
 
@@ -269,7 +305,7 @@
         this._viewportInfo.content = this._viewportInfo._fullScreenContent;
       } else {
         window.addEventListener('resize', this._resizeHandler);
-        this.async(this._updateOverlayAlignment);
+        this.$.dropdown.addEventListener('iron-resize', this._resizeHandler);
       }
 
       this._iOSOpened();
@@ -286,9 +322,9 @@
         var rect = this.getBoundingClientRect();
         this.$.dropdown.style.left = -rect.left + 'px';
         this.$.dropdown.style.top = -rect.top + 'px';
-
-        this._iOSReposition();
       }
+
+      this._iOSReposition();
     },
 
     /**
@@ -299,6 +335,7 @@
         this._viewportInfo.content = this._viewportInfo._originalContent;
       } else {
         window.removeEventListener('resize', this._resizeHandler);
+        this.$.dropdown.removeEventListener('iron-resize', this._resizeHandler);
       }
     },
 
@@ -314,14 +351,25 @@
     },
 
     _updateOverlayAlignment: function() {
+      if (!this.$.dropdown.positionTarget) return;
+
+      if (this.ios && !this.fullScreen) {
+        // trigger rendering to fix iOS Safari disappearing items issue
+        this.$.dropdown.offsetWidth;
+      }
+
       var rect = this.$.dropdown.positionTarget.getBoundingClientRect();
       var spaceBelow = window.innerHeight - rect.bottom;
       var alignedToBottom = spaceBelow < this.alignThreshold && spaceBelow < rect.top;
-      this._verticalAlign = alignedToBottom ? 'bottom' : 'top';
+      // Always open the dropdown at the bottom on iOS. iOS scrolls the focused
+      // inputs into view, so there’s alsways more space below the input.
+      this._verticalAlign = alignedToBottom && !this.ios ? 'bottom' : 'top';
+
+      this.$.dropdown.fit();
     },
 
     _iOSRepositionAsync: function() {
-      if (this.fullScreen && this.ios && this.opened) {
+      if (this.ios && this.opened) {
         this._iOSReposition();
         // Also reposition asynchronously as the scroll shift might
         // be delayed due to orientation change or focus animation.
@@ -330,7 +378,9 @@
     },
 
     _iOSReposition: function() {
-      if (this.fullScreen && this.ios && this.opened) {
+      if (!this.ios || !this.opened) return;
+
+      if (this.fullScreen) {
         // Scroll back to the dropdown (scroll might have shifted due to input focus for example)
         var rect = this.$.dropdown.getBoundingClientRect();
         window.scrollBy(rect.left, rect.top);
@@ -345,6 +395,8 @@
           backdrop.style.left = -rect.left + 'px';
           backdrop.style.top = -rect.top + 'px';
         });
+      } else {
+        this._updateOverlayAlignment();
       }
     }
   });

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -134,6 +134,18 @@
         }
       },
 
+      _touchDevice: {
+        readOnly: true,
+        value: function() {
+          try {
+            document.createEvent('TouchEvent');
+            return true;
+          } catch (e) {
+            return false;
+          }
+        }
+      },
+
       /**
        * The pixel value that being compared with bottom offset of the input element will
        * make the popup be shown above the input.
@@ -376,16 +388,16 @@
     },
 
     _iOSRepositionAsync: function() {
-      if (this.ios && this.opened) {
+      if (this._touchDevice && this.opened) {
         this._iOSReposition();
         // Also reposition asynchronously as the scroll shift might
         // be delayed due to orientation change or focus animation.
-        this.async(this._iOSReposition, 500);
+        this.async(this._iOSReposition, 1000);
       }
     },
 
     _iOSReposition: function() {
-      if (!this.ios || !this.opened) return;
+      if (!this._touchDevice || !this.opened) return;
 
       if (this.fullScreen) {
         // Scroll back to the dropdown (scroll might have shifted due to input focus for example)

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -306,6 +306,9 @@
       } else {
         window.addEventListener('resize', this._resizeHandler);
         this.$.dropdown.addEventListener('iron-resize', this._resizeHandler);
+
+        this.$.dropdownContent.style.minHeight = '0';
+        this.$.dropdownContent.style.minHeight = Math.min(this.scroller.scrollHeight, 300) + 'px';
       }
 
       this._iOSOpened();

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -13,9 +13,13 @@
     }
 
     #dropdown[fullscreen],
+    #dropdown[fullscreen]::content #contentWrapper {
+      height: 100vh;
+    }
+
+    #dropdown[fullscreen],
     #dropdown[fullscreen]::content #contentWrapper,
     #dropdown[fullscreen] .dropdown-content {
-      height: 100vh;
       max-height: 100vh;
       width: 100vw;
       max-width: 100vw;

--- a/vaadin-adaptive-overlay.html
+++ b/vaadin-adaptive-overlay.html
@@ -35,6 +35,11 @@
       position: absolute;
     }
 
+    #dropdown:not([fullscreen]) {
+      position: absolute;
+      left: 0px !important;
+    }
+
     /* Override the conflicting top/bottom values not cleared by iron-dropdown */
     #dropdown[vertical-align='top'] {
       bottom: auto !important;
@@ -56,6 +61,7 @@
       on-tap="_tapped"
       on-iron-overlay-closed="_closed"
       on-iron-overlay-opened="_opened"
+      allow-outside-scroll="[[_allowOutsideScroll(fullScreen)]]"
       on-iron-resize="_iOSRepositionAsync">
       <div id="dropdownContent" class="dropdown-content" on-touchend="_iOSRepositionAsync">
         <content>
@@ -168,6 +174,10 @@
       }
     },
 
+    _allowOutsideScroll: function(fullScreen) {
+      return !fullScreen;
+    },
+
     _computePositionTarget: function(fullScreen) {
       return fullScreen ? document.documentElement : this.domHost || this.parentElement;
     },
@@ -189,11 +199,11 @@
     },
 
     _computeVerticalOffset: function(opened, positionTarget, fullScreen, _verticalAlign) {
-      var verticalOffset = 0;
+      var verticalOffset = _verticalAlign == 'top' ? 0 : positionTarget.clientHeight;
+
+      var target = 0;
 
       if (!fullScreen && positionTarget) {
-        verticalOffset = positionTarget.clientHeight;
-
         // In Safari, when dropdown is positioned on non-integer vertical
         // coordinate, the items text is sometimes rendered 1 device pixel line
         // outside the dropdown during vertical scrolling.
@@ -202,7 +212,7 @@
         // offset by a small error-correcting value, to make the vertical
         // coordinate of the dropdown an integer number of device pixels.
 
-        var target = this._computeVerticalAlignTargetValue(positionTarget, _verticalAlign);
+        target = this._computeVerticalAlignTargetValue(positionTarget, _verticalAlign);
         // We can't use the <iron-dropdown/>’s _verticalAlignTargetValue
         // property getter instead, because it depends on the verticalOffset.
 
@@ -210,7 +220,7 @@
         verticalOffset += Math.round(target * devicePixelRatio) / devicePixelRatio - target;
       }
 
-      return verticalOffset;
+      return verticalOffset - target;
     },
 
     _verticalAlignChanged: function() {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -512,7 +512,15 @@ enable usage within an `iron-form`.
           this._scrollIntoView(this._focusedIndex);
         }, 1);
 
+        this._temporaryListenerNameThisBetterAfterwards = this._blurInput.bind(this);
+        document.addEventListener('touchstart', this._temporaryListenerNameThisBetterAfterwards);
+
       } else {
+        if (this._temporaryListenerNameThisBetterAfterwards) {
+          document.removeEventListener('touchstart', this._temporaryListenerNameThisBetterAfterwards);
+          this._temporaryListenerNameThisBetterAfterwards = undefined;
+        }
+
         this.$.input.bindValue = this.value;
         this.$.fullScreenInput.bindValue = this.value;
         if (fullScreen) {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -207,10 +207,10 @@ enable usage within an `iron-form`.
 
     <!-- Having spaces between elements inside <content> template in vaadin-adaptive-overlay causes scrolling throw errors when using Shadow DOM or IE11. See https://github.com/PolymerElements/iron-dropdown/issues/27 -->
     <vaadin-adaptive-overlay id='overlay' role="listbox"
-         focus-target=[[_getFocusTarget()]] opened={{opened}} data-selection$='[[_getAriaActiveIndex(_focusedIndex)]]'><paper-input-container opened$=[[opened]]>
+        focus-target=[[_focusTarget]] opened={{opened}} data-selection$='[[_getAriaActiveIndex(_focusedIndex)]]' full-screen={{_fullScreen}}><paper-input-container class="toolbar" opened$=[[opened]]>
         <label>[[label]]</label><input id='fullScreenInput' autocomplete='off' is='iron-input' bind-value='[[value]]' on-bind-value-changed='_fullScreenInputValueChanged' on-blur='_onBlur'>
         <div suffix on-tap='close'><iron-icon icon='arrow-drop-down'></iron-icon><paper-ripple class='circle' center></paper-ripple></div>
-      </paper-input-container><iron-list id='selector' on-touchend="_preventDefault" on-down='_blurFullScreenInput' items='[[items]]' selected-item='[[value]]' on-selected-item-changed='_selectedItemChanged' selection-enabled>
+      </paper-input-container><iron-list id='selector' on-touchend="_preventDefault" on-down='_iOSBlurInput' items='[[items]]' selected-item='[[value]]' on-selected-item-changed='_selectedItemChanged' selection-enabled>
         <template>
           <div class='item'
           id$="it[[index]]"
@@ -272,6 +272,15 @@ enable usage within an `iron-form`.
         type: Number,
         value: -1,
         observer: '_focusedIndexChanged'
+      },
+
+      _focusTarget: {
+        type: Object,
+        computed: '_computeFocusTarget(_fullScreen)'
+      },
+
+      _fullScreen: {
+        type: Boolean
       }
     },
 
@@ -280,8 +289,8 @@ enable usage within an `iron-form`.
       Polymer.IronA11yAnnouncer.requestAvailability();
     },
 
-    _getFocusTarget: function() {
-      return this.$.overlay.fullScreen ? this.$.fullScreenInput : this.$.input;
+    _computeFocusTarget: function(fullScreen) {
+      return fullScreen ? this.$.fullScreenInput : this.$.input;
     },
 
     /**
@@ -447,8 +456,15 @@ enable usage within an `iron-form`.
       }
     },
 
-    _blurFullScreenInput: function() {
-      this.$.fullScreenInput.blur();
+    _iOSBlurInput: function() {
+      if (this.$.overlay.ios) {
+        // On iOS the input fields have to be defocused to hide the virtual
+        // keyboard that might overlay the dropdown. No need to hide the
+        // virtual keyboard on Android though: the viewport size is correct in
+        // that case, it doesn't include the virtual keyboard.
+        this.$.input.blur();
+        this.$.fullScreenInput.blur();
+      }
     },
 
     _setItems: function(items) {
@@ -485,7 +501,7 @@ enable usage within an `iron-form`.
     },
 
     _openedChanged: function() {
-      var fullScreen = this.$.overlay.fullScreen;
+      var fullScreen = this._fullScreen;
       this.$.input.tabIndex = fullScreen && this.opened ? -1 : 0;
 
       if (this.opened) {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -512,7 +512,7 @@ enable usage within an `iron-form`.
           this._scrollIntoView(this._focusedIndex);
         }, 1);
 
-        this._temporaryListenerNameThisBetterAfterwards = this._blurInput.bind(this);
+        this._temporaryListenerNameThisBetterAfterwards = this._iOSBlurInput.bind(this);
         document.addEventListener('touchstart', this._temporaryListenerNameThisBetterAfterwards);
 
       } else {


### PR DESCRIPTION
Resolves #23.

From now and then the overlay opens in full screen mode when the viewport
width is below the `responsiveWidth` property value (600px by default). The
viewport width check is performed each time the overlay opens.

The `fullScreen` overlay’s property changed to be read-only. The full
screen mode can be turned on manually by setting the overlay’s
`forceFullScreen` property to `true`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/90)
<!-- Reviewable:end -->
