### PR TITLE
Add Overview page and split old example page into two separate ones

### DIFF
--- a/demo/basic.html
+++ b/demo/basic.html
@@ -1,0 +1,72 @@
+<!doctype html>
+<!--
+title: Basic Usage
+order: 1
+layout: page
+-->
+<html>
+
+<head>
+  <title>vaadin-combo-box Code Examples - Basic Usage</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="common.html">
+  <link rel="import" href="../../iron-form/iron-form.html">
+
+  <style is="custom-style">
+    :root {
+      --default-primary-color: #2899f2;
+      --secondary-text-color: rgba(0,0,0,.12);
+    }
+  </style>
+</head>
+
+<body unresolved>
+  <section>
+    <h1><a href="./">vaadin-combo-box</a>
+      <span>Basic Usage</span>
+    </h1>
+    <table-of-contents select="h3" class="toc"></table-of-contents>
+  </section>
+
+  <section>
+    <h3>Configuration</h3>
+    <p>
+      The data items displayed by <code>vaadin-combo-box</code> can be set and accessed using the
+      <code>items</code> property. The <code>items</code> may be assigned with data-binding, using an attribute or the
+      JavaScript property directly. Notice that only an array of <code>String</code> values or <code>Object</code>s
+      with a <code>toString()</code> method is currently supported.
+      Use the <code>label</code> attribute to provide a label for the element.
+    </p>
+    <p>
+      Typing some text into the <code>vaadin-combo-box</code>'s input field will filter
+      the values defined in the <code>items</code> property and show only items that
+      <code>contain</code> the value in the input field.
+    </p>
+
+    <code-example source>
+      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
+
+      <code demo-var="combobox">
+        var combobox = combobox || document.querySelector('vaadin-combo-box');
+
+        // The elements is an array of String values.
+        combobox.items = elements;
+      </code>
+    </code-example>
+  </section>
+
+  <section>
+    <h3>Automatic sizing and alignment</h3>
+    <p>
+      In desktop browsers, the dropdown adapts its size to the available space keeping it
+      from overflowing outside the window edges. The dropdown also changes its alignment
+      from bottom to top depending on which side has more space available.
+    </p>
+    <p>Try resizing the window to see how the dropdown adapts its size and alignment.</p>
+  </section>
+
+</body>
+
+</html>

--- a/demo/common.html
+++ b/demo/common.html
@@ -13,4 +13,26 @@
     '  <script src="https://cdn.vaadin.com/vaadin-components/latest/webcomponentsjs/webcomponents-lite.js"><\/script>\n' +
     '  <link href="https://cdn.vaadin.com/vaadin-components/latest/vaadin-combo-box/vaadin-combo-box.html" rel="import">\n' +
     '  <script>var randomUserUrl = "' + randomUserUrl + '";<\/script>\n';
+
+    var elements = ['Actinium', 'Aluminium', 'Americium', 'Antimony', 'Argon',
+        'Arsenic', 'Astatine', 'Barium', 'Berkelium', 'Beryllium', 'Bismuth',
+        'Bohrium', 'Boron', 'Bromine', 'Cadmium', 'Caesium', 'Calcium',
+        'Californium', 'Carbon', 'Cerium', 'Chlorine', 'Chromium', 'Cobalt',
+        'Copernicium', 'Copper', 'Curium', 'Darmstadtium', 'Dubnium',
+        'Dysprosium', 'Einsteinium', 'Erbium', 'Europium', 'Fermium',
+        'Flerovium', 'Fluorine', 'Francium', 'Gadolinium', 'Gallium',
+        'Germanium', 'Gold', 'Hafnium', 'Hassium', 'Helium', 'Holmium',
+        'Hydrogen', 'Indium', 'Iodine', 'Iridium', 'Iron', 'Krypton',
+        'Lanthanum', 'Lawrencium', 'Lead', 'Lithium', 'Livermorium', 'Lutetium',
+        'Magnesium', 'Manganese', 'Meitnerium', 'Mendelevium', 'Mercury',
+        'Molybdenum', 'Neodymium', 'Neon', 'Neptunium', 'Nickel', 'Niobium',
+        'Nitrogen', 'Nobelium', 'Osmium', 'Oxygen', 'Palladium', 'Phosphorus',
+        'Platinum', 'Plutonium', 'Polonium', 'Potassium', 'Praseodymium',
+        'Promethium', 'Protactinium', 'Radium', 'Radon', 'Rhenium', 'Rhodium',
+        'Roentgenium', 'Rubidium', 'Ruthenium', 'Rutherfordium', 'Samarium',
+        'Scandium', 'Seaborgium', 'Selenium', 'Silicon', 'Silver', 'Sodium',
+        'Strontium', 'Sulfur', 'Tantalum', 'Technetium', 'Tellurium', 'Terbium',
+        'Thallium', 'Thorium', 'Thulium', 'Tin', 'Titanium', 'Tungsten',
+        'Ununoctium', 'Ununpentium', 'Ununseptium', 'Ununtrium', 'Uranium',
+        'Vanadium', 'Xenon', 'Ytterbium', 'Yttrium', 'Zinc', 'Zirconium'];
   </script>

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,191 +1,23 @@
 <!doctype html>
 <html>
-
 <head>
-  <title>vaadin-combo-box Code Examples - basic</title>
+  <title>vaadin-combo-box Code Examples</title>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="common.html">
-  <link rel="import" href="../../iron-form/iron-form.html">
-
-  <style is="custom-style">
-    :root {
-      --default-primary-color: #2899f2;
-      --secondary-text-color: rgba(0,0,0,.12);
-    }
-  </style>
-  <script>
-    var elements = ['Actinium', 'Aluminium', 'Americium', 'Antimony', 'Argon',
-        'Arsenic', 'Astatine', 'Barium', 'Berkelium', 'Beryllium', 'Bismuth',
-        'Bohrium', 'Boron', 'Bromine', 'Cadmium', 'Caesium', 'Calcium',
-        'Californium', 'Carbon', 'Cerium', 'Chlorine', 'Chromium', 'Cobalt',
-        'Copernicium', 'Copper', 'Curium', 'Darmstadtium', 'Dubnium',
-        'Dysprosium', 'Einsteinium', 'Erbium', 'Europium', 'Fermium',
-        'Flerovium', 'Fluorine', 'Francium', 'Gadolinium', 'Gallium',
-        'Germanium', 'Gold', 'Hafnium', 'Hassium', 'Helium', 'Holmium',
-        'Hydrogen', 'Indium', 'Iodine', 'Iridium', 'Iron', 'Krypton',
-        'Lanthanum', 'Lawrencium', 'Lead', 'Lithium', 'Livermorium', 'Lutetium',
-        'Magnesium', 'Manganese', 'Meitnerium', 'Mendelevium', 'Mercury',
-        'Molybdenum', 'Neodymium', 'Neon', 'Neptunium', 'Nickel', 'Niobium',
-        'Nitrogen', 'Nobelium', 'Osmium', 'Oxygen', 'Palladium', 'Phosphorus',
-        'Platinum', 'Plutonium', 'Polonium', 'Potassium', 'Praseodymium',
-        'Promethium', 'Protactinium', 'Radium', 'Radon', 'Rhenium', 'Rhodium',
-        'Roentgenium', 'Rubidium', 'Ruthenium', 'Rutherfordium', 'Samarium',
-        'Scandium', 'Seaborgium', 'Selenium', 'Silicon', 'Silver', 'Sodium',
-        'Strontium', 'Sulfur', 'Tantalum', 'Technetium', 'Tellurium', 'Terbium',
-        'Thallium', 'Thorium', 'Thulium', 'Tin', 'Titanium', 'Tungsten',
-        'Ununoctium', 'Ununpentium', 'Ununseptium', 'Ununtrium', 'Uranium',
-        'Vanadium', 'Xenon', 'Ytterbium', 'Yttrium', 'Zinc', 'Zirconium'];
-  </script>
-
+  <link rel="stylesheet" href="../../elements-demo-resources/demo.css">
+  <script src="../../elements-demo-resources/ga.js"></script>
 </head>
-
-<body unresolved>
-  <section>
-    <h1>vaadin-combo-box
-      <span>Basic</span>
-    </h1>
-    <table-of-contents select="h3" class="toc"></table-of-contents>
-  </section>
+<body>
 
   <section>
-    <h3>Setting items and label</h3>
-    <p>
-      The data items displayed by <code>vaadin-combo-box</code> can be set and accessed using the
-      <code>items</code> property. Only an array of <code>String</code> values is currently supported.
-      The <code>items</code> may be assigned with data-binding, using an attribute or the
-      JavaScript property directly.
-    </p>
-    <p>Use the <code>label</code> attribute to provide a label for the element.</p>
+    <h1>vaadin-combo-box <span>Code Examples</span></h1>
 
-    <code-example source>
-      <vaadin-combo-box demo label="Fruit"></vaadin-combo-box>
-
-      <code demo-var="combobox">
-        var combobox = combobox || document.querySelector('vaadin-combo-box');
-        combobox.items = ['apple', 'orange', 'banana'];
-      </code>
-    </code-example>
-  </section>
-
-  <section>
-    <h3>Filtering</h3>
-    <p>
-      Typing some text into the <code>vaadin-combo-box</code>'s input field will filter
-      the values defined in the <code>items</code> property and show only items that
-      <code>contain</code> the value in the input field.
-    </p>
-    <code-example source>
-      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
-      <code demo-var="combobox">
-        var combobox = combobox || document.querySelector('vaadin-combo-box');
-        combobox.items = elements;
-      </code>
-    </code-example>
-  </section>
-
-  <section>
-    <h3>Opening and closing</h3>
-    <p>
-      <code>vaadin-combo-box</code> dropdown list can be opened by clicking/tapping the element,
-      using up/down arrow keys or programmatically with the <code>open()</code> method.
-    </p>
-    <p>
-      Selecting a value, clicking outside the dropdown, using esc key or clicking/tapping the
-      close icon closes the dropdown.
-      <code>vaadin-combo-box</code> also has an explicit <code>close()</code> method.
-    </p>
-    <p>
-      Current state can be accessed with the <code>opened</code> property.
-    </p>
-
-    <code-example source>
-      <button id="togglebutton">Toggle dropdown</button>
-      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
-
-      <code demo-var="combobox">
-        var combobox = combobox || document.querySelector('vaadin-combo-box');
-        combobox.items = elements;
-
-        var togglebutton = document.querySelector('#togglebutton');
-        togglebutton.addEventListener('click', function() {
-          if (combobox.opened) {
-            combobox.close();
-          } else {
-            combobox.open();
-          }
-        });
-      </code>
-    </code-example>
-  </section>
-
-  <section>
-    <h3>Selecting a value</h3>
-    <p>
-      Selecting a value from the dropdown list changes <code>vaadin-combo-box</code>'s
-      <code>value</code> property and triggers a <code>value-changed</code> event.
-    </p>
-    <p>Changing the <code>value</code> property explicitly also updates the visible fields.</p>
-
-    <code-example source>
-      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
-      <p>Selected value: <span id="selected-value"></span>.</p>
-
-      <code demo-var="combobox">
-        var combobox = combobox || document.querySelector('vaadin-combo-box');
-        combobox.items = elements;
-
-        combobox.addEventListener('value-changed', function() {
-          document.querySelector('#selected-value').innerHTML = combobox.value;
-        });
-        combobox.value = 'Carbon';
-      </code>
-    </code-example>
-  </section>
-
-  <section>
-    <h3>Using as a form field</h3>
-    <p>
-      <code>vaadin-combo-box</code> is extended with <code>IronFormElementBehavior</code> so it can
-      be used as a field in an <code>iron-form</code>.
-    </p>
-
-    <code-example source>
-      <form is="iron-form" method="post" demo>
-        <vaadin-combo-box name='name' required label="Element"></vaadin-combo-box>
-        <button>Submit</button>
-      </form>
-      <code demo-var="form">
-        var form = form || document.querySelector('form');
-        var combobox = form.querySelector('vaadin-combo-box');
-        combobox.items = elements;
-
-        form.addEventListener('iron-form-submit', function() {
-          alert('Form submitted with name: ' + form.serialize().name);
-          return false;
-        });
-      </code>
-    </code-example>
-  </section>
-
-  <section>
-    <h3>Automatic sizing and alignment</h3>
-    <p>
-      In desktop browsers, the dropdown adapts its size to the available space keeping it
-      from overflowing outside the window edges. The dropdown also changes its alignment
-      from bottom to top depending on which side has more space available.
-    </p>
-    <p>Try resizing the window to see how the dropdown adapts its size and alignment.</p>
-    <code-example source>
-      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
-      <code demo-var="combobox">
-        var combobox = combobox || document.querySelector('vaadin-combo-box');
-        combobox.items = elements;
-      </code>
-    </code-example>
+    <ul class="toc">
+      <li><a href="overview.html">Overview</a></li>
+      <li><a href="basic.html">Basic Usage</a></li>
+      <li><a href="value-handling.html">Value Handling</a></li>
+    </ul>
   </section>
 
 </body>
-
 </html>

--- a/demo/overview.html
+++ b/demo/overview.html
@@ -1,0 +1,90 @@
+<!doctype html>
+<!--
+title: Overview
+order: 0
+layout: page
+-->
+<html>
+  <head>
+    <title>vaadin-combo-box Code Examples - Overview</title>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+    <link rel="import" href="common.html">
+  </head>
+
+  <body unresolved>
+    <section>
+      <h1><a href="./">vaadin-combo-box</a>
+        <span>Overview</span>
+      </h1>
+      <table-of-contents select="h3" class="toc"></table-of-contents>
+    </section>
+
+    <section>
+      <h3>Overview</h3>
+      <p>
+        The <code>vaadin-combo-box</code> is a combo box element combining a dropdown list with an input field for
+        filtering the list of items. It is also a part of the <a href="https://github.com/vaadin/vaadin-core-elements">vaadin-core-elements</a>
+        element bundle. See a detailed list of features on the <a href="https://vaadin.com/elements">vaadin-combo-box page</a>.
+      </p>
+      <p>
+        The following chapters will guide you through the usage of <code>vaadin-combo-box</code> with code examples.
+        <dl>
+          <dt><a href="basic.html">Basic Usage</a></dt>
+          <dd>
+            Basic Usage chapter shows you how to configure the element correctly and explains the automatic
+            sizing and alignment feature.
+          </dd>
+          <dt><a href="value-handling.html">Value Handling</a></dt>
+          <dd>
+            Value Handling chapter explains how you can listen for changes in the selected value and how to
+            use the element inside a form.
+          </dd>
+        </dl>
+      </p>
+
+      <h3>Getting started</h3>
+      <p>
+        To install <code>vaadin-combo-box</code> to your project, you have three options. The recommended way
+        is to use <a href="http://bower.io/">Bower</a>.
+      </p>
+
+      <h4>1) Bower</h4>
+      <p>
+        Recommended way for installation is to use the Bower package manager. After creating a folder for your project,
+        you can install the element (with all required dependencies) with the following command.
+      </p>
+      <pre><code>$ bower install --save vaadin-combo-box</code></pre>
+      <p>Then use a normal HTML import to make the element available on your page.</p>
+      <pre><code>&lt;link rel=&quot;import&quot; href=&quot;bower_components/vaadin-combo-box/vaadin-combo-box.html&quot;&gt;</code></pre>
+
+      <h4>2) Vaadin CDN</h4>
+      <p>
+        You can also import the element without a local installation by using our CDN infrastructure.
+      </p>
+      <pre><code>&lt;link rel=&quot;import&quot; href=&quot;https://cdn.vaadin.com/vaadin-core-elements/latest/vaadin-combo-box/vaadin-combo-box.html&quot;&gt;</code></pre>
+
+      <h4>3) ZIP Download </h4>
+      <p>
+        As a third option, you can also download the required files locally by downloading the latest
+        Vaadin Core Elements bundle as a <a href="https://vaadin.com/download#elements">zip package</a>.
+      </p>
+      <pre><code>&lt;link rel=&quot;import&quot; href=&quot;libs/vaadin-combo-box/vaadin-combo-box.html&quot;&gt;</code></pre>
+
+      <h3>Limitations</h3>
+      <p>
+        Currently the options displayed in the dropdown list is limited to an array of <code>String</code> values
+        or <code>Object</code>s with a <code>toString()</code> method.
+        Lazy loading of the list items is not supported.
+      </p>
+
+      <h3>License and Source Code</h3>
+      <p>
+        The <code>vaadin-combo-box</code> element is licensed under the
+        <a href="https://github.com/vaadin/vaadin-combo-box/blob/master/LICENSE.md">Apache License 2.0</a>. The
+        source code is available on the <a href="https://github.com/vaadin/vaadin-combo-box">GitHub project page</a>.
+      </p>
+    </section>
+  </body>
+</html>

--- a/demo/value-handling.html
+++ b/demo/value-handling.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<!--
+title: Value Handling
+order: 2
+layout: page
+-->
+<html>
+
+<head>
+  <title>vaadin-combo-box Code Examples - Value Handling</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
+  <link rel="import" href="common.html">
+  <link rel="import" href="../../iron-form/iron-form.html">
+
+  <style is="custom-style">
+    :root {
+      --default-primary-color: #2899f2;
+      --secondary-text-color: rgba(0,0,0,.12);
+    }
+  </style>
+</head>
+
+<body unresolved>
+  <section>
+    <h1><a href="./">vaadin-combo-box</a>
+      <span>Value Handling</span>
+    </h1>
+    <table-of-contents select="h3" class="toc"></table-of-contents>
+  </section>
+
+  <section>
+    <h3>Selecting a value</h3>
+    <p>
+      Selecting a value from the dropdown list changes <code>vaadin-combo-box</code>'s
+      <code>value</code> property and triggers a <code>value-changed</code> event.
+      Changing the <code>value</code> property explicitly also updates the visible fields.
+    </p>
+
+    <code-example source>
+      <vaadin-combo-box demo label="Element"></vaadin-combo-box>
+      <p>Selected value: <span id="selected-value"></span>.</p>
+
+      <code demo-var="combobox">
+        var combobox = combobox || document.querySelector('vaadin-combo-box');
+        combobox.items = elements;
+
+        combobox.addEventListener('value-changed', function() {
+          document.querySelector('#selected-value').innerHTML = combobox.value;
+        });
+        combobox.value = 'Carbon';
+      </code>
+    </code-example>
+  </section>
+
+  <section>
+    <h3>Using as a form field</h3>
+    <p>
+      The <code>vaadin-combo-box</code> element is also extended with
+      <a href="https://elements.polymer-project.org/elements/iron-form-element-behavior"><code>IronFormElementBehavior</code></a>
+      so it can be used as a field in an <a href="https://elements.polymer-project.org/elements/iron-form"><code>iron-form</code></a>.
+      See the code below for an example on how it works.
+    </p>
+
+    <code-example source>
+      <form is="iron-form" method="post" demo>
+        <vaadin-combo-box name='name' required label="Element"></vaadin-combo-box>
+        <button>Submit</button>
+      </form>
+      <code demo-var="form">
+        var form = form || document.querySelector('form');
+        var combobox = form.querySelector('vaadin-combo-box');
+        combobox.items = elements;
+
+        form.addEventListener('iron-form-submit', function() {
+          alert('Form submitted with name: ' + form.serialize().name);
+          return false;
+        });
+      </code>
+    </code-example>
+  </section>
+
+</body>
+
+</html>


### PR DESCRIPTION
Connects to vaadin/components-team-tasks/issues/63

This PR adds an Overview page to the documentation. The structure of this page was earlier discussed with @jounik and I tried to follow our initial ideas (mainly of keeping the actual feature list out of the page and leaving it for the marketing material).

In addition this PR also splits the old single demo page into Basic Usage and Value Handling pages. The example of ```open()``` and ```close()``` API was intentionally left out as it is quite trivial. These were also discussed with @jounik earlier.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/102)
<!-- Reviewable:end -->
