### PR TITLE
Close overlay when document.body becomes the active element.

### DIFF
--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -20,6 +20,7 @@
     #scroller {
       overflow: auto;
       max-height: 65vh;
+      outline: none;
 
       /* Fixes item background from getting on top of scrollbars on Safari */
       transform: translate3d(0,0,0);
@@ -50,7 +51,7 @@
   </style>
 
   <template>
-    <div id="scroller" scroller="[[_getScroller()]]">
+    <div id="scroller" scroller="[[_getScroller()]]" tabindex="-1">
       <iron-list
           id="selector"
           touch-device$="[[touchDevice]]"

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -279,10 +279,9 @@ enable usage within an `iron-form`.
       // Async needed to access the new activeElement reliably.
       this.async(function() {
         var focusInsideCombobox = this.contains(document.activeElement);
+        var focusInsideOverlay = this.$.overlay.contains(document.activeElement);
 
-        // When grabbing the scroll handle, the activeElement will become
-        // the body on some browsers, so check for it also.
-        if (!focusInsideCombobox && document.activeElement !== document.body) {
+        if (!focusInsideCombobox && !focusInsideOverlay) {
           this.close();
         }
       }, 1);


### PR DESCRIPTION
Fixes #122 

Tried to create a solid unit test for this but, that unfortunately failed.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/123)
<!-- Reviewable:end -->
