### PR TITLE
Focus overlay explicitly when clicked on.

### DIFF
--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -76,6 +76,14 @@
       combobox.$.overlay.$.selector.toggleSelectionForItem('foo');
       expect(valueChangedSpy.callCount).to.equal(0);
     });
+
+    it('should focus on overlay when items are clicked on', function() {
+      combobox.open();
+
+      var item = combobox.$.overlay.fire('down');
+
+      expect(document.activeElement).to.eql(combobox.$.overlay.$.scroller);
+    });
   });
 
   describe('clearing a selection', function() {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -137,7 +137,7 @@ enable usage within an `iron-form`.
         _selected-item="{{_selectedItem}}"
         position-target="[[_positionTarget]]"
         _focused-index="[[_focusedIndex]]"
-        on-down="_blurInput"
+        on-down="_focusOverlay"
         vertical-offset="2">
     </vaadin-combo-box-overlay>
   </template>
@@ -312,8 +312,8 @@ enable usage within an `iron-form`.
       }, 1);
     },
 
-    _blurInput: function() {
-      this.$.input.blur();
+    _focusOverlay: function() {
+      this.$.overlay.$.scroller.focus();
     },
 
     /**


### PR DESCRIPTION
We are effectively blurring the input field when overlay is tapped in order to
hide the virtual keyboard on touch devices.

However, at least on WIN10 IE11 and Edge the focus is moved to document.body
when the input is blurred, forcing the overlay to be closed and selected value
to be reverted.

Setting the focus to overlay (#scroller) now that it has tabindex fixes this,
and also makes the code reflect better on what we're trying to achieve.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/132)
<!-- Reviewable:end -->
