### PR TITLE
Modify selection range only when input is focused

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,4 +1,6 @@
 var ios = /iPad|iPhone|iPod/.test(navigator.userAgent) && !window.MSStream;
+var safari = navigator.userAgent.toLowerCase().indexOf('safari/') > -1 && navigator.userAgent.toLowerCase().indexOf('chrome/') == -1;
+
 var touchDevice = (function() {
   try {
     document.createEvent('TouchEvent');

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -279,7 +279,10 @@
         expect(getInput().bindValue).to.eql('bar');
       });
 
-      if (!touchDevice) {
+      // Safari window doesn't have focus in SauceLabs which prevents input fields from focusing also.
+      // iPad and iPhone simulators have the same issue. As a note, touch devices seem to clear the selection
+      // natively when blurring an input.
+      if (!safari && !touchDevice) {
         it('should remove selection from the input value selecting value', function() {
           arrowDown();
 

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -414,13 +414,15 @@ enable usage within an `iron-form`.
       this.$.input.setSelectionRange(0, this.$.input.bindValue.length);
     },
 
-    _clearSelectionRange: function() {
-      // in touch devices, iOS especially, setting selection range focuses the input.
-      // however, selection range seems to be cleared natively on blur, so there's no need to clear manually.
+    // document.activeElement doesn't return elements from inside shadow root
+    _focusedInput: function() {
+      return Polymer.dom(this.root).querySelector('input:focus');
+    },
 
-      // parentElement is used to check that combo-box is attached to the DOM, IE11 generate errors
-      // when setting selection range while detached. (sigh)
-      if (!this.$.overlay.touchDevice && this.parentElement) {
+    _clearSelectionRange: function() {
+      // Setting selection range focuses and/or moves the caret in some browsers,
+      // and there's no need to modify the selection range if the input isn't focused anyway.
+      if (this._focusedInput() === this.$.input) {
         this.$.input.setSelectionRange(this.$.input.bindValue.length, this.$.input.bindValue.length);
       }
     },


### PR DESCRIPTION
Fixes #138 

Turned out modifying the selection range of an input focuses the input
in some browsers, and in some browsers it actually activates the caret
without actually focusing the input. Modifying the selection range after
the overlay was closed and focus lost in the input caused interesting issues.

Problem was solved simply by checking if the input has focus before modifying
the selection range.

Like seen before, making stable automated tests that rely on focus states
proved to be unfeasible.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/139)
<!-- Reviewable:end -->
