### PR TITLE
Disable custom values by default

### DIFF
--- a/demo/value-handling.html
+++ b/demo/value-handling.html
@@ -65,8 +65,9 @@ layout: page
       needs to be explicitly enabled.
     </p>
     <p>
-      When enabled, inputed custom values will be always set as the <code>value</code>.
-      If you need to prevent that from happening, you can provide your own handler for the custom values.
+      When enabled, custom input values are always accepted and used as the <code>value</code> of the combo box.
+      If you need to cancel the automatic assignment, you can provide your own listener for the <code>custom-value-set</code> event
+      that prevents the default behavior.
     </p>
     <code-example source>
         <vaadin-combo-box demo label="Element" allow-custom-value></vaadin-combo-box>
@@ -82,11 +83,11 @@ layout: page
               document.querySelector('#selected-value2').innerHTML = combobox.value;
             });
 
-            combobox.addEventListener('custom-value', function(e) {
+            combobox.addEventListener('custom-value-set', function(e) {
               // Prevents setting the value property automatically.
               e.preventDefault();
 
-              combobox.value = 'custom value "' + e.detail + '" added!';
+              combobox.value = 'custom value "' + e.detail + '" set!';
             });
 
             combobox.value = 'Carbon';

--- a/demo/value-handling.html
+++ b/demo/value-handling.html
@@ -59,6 +59,44 @@ layout: page
   </section>
 
   <section>
+    <h3>Using Custom Values</h3>
+    <p>
+      Users can be allowed also to input their own custom values. By default, this feature is disabled, so it
+      needs to be explicitly enabled.
+    </p>
+    <p>
+      When enabled, inputed custom values will be always set as the <code>value</code>.
+      If you need to prevent that from happening, you can provide your own handler for the custom values.
+    </p>
+    <code-example source>
+        <vaadin-combo-box demo label="Element" allow-custom-value></vaadin-combo-box>
+        <p>Selected value: <span id="selected-value2"></span></p>
+
+        <code demo-var="combobox">
+          HTMLImports.whenReady(function() {
+            // code
+            var combobox = document.querySelectorAll('vaadin-combo-box')[1];
+            combobox.items = elements;
+
+            combobox.addEventListener('value-changed', function() {
+              document.querySelector('#selected-value2').innerHTML = combobox.value;
+            });
+
+            combobox.addEventListener('custom-value', function(e) {
+              // Prevents setting the value property automatically.
+              e.preventDefault();
+
+              combobox.value = 'custom value "' + e.detail + '" added!';
+            });
+
+            combobox.value = 'Carbon';
+            // end-code
+          });
+        </code>
+    </code-example>
+  </section>
+
+  <section>
     <h3>Using as a form field</h3>
     <p>
       The <code>vaadin-combo-box</code> element is also extended with

--- a/docs/vaadin-combo-box-basic.adoc
+++ b/docs/vaadin-combo-box-basic.adoc
@@ -11,11 +11,11 @@ layout: page
 You need to provide the set of items which the user can select with the [propertyname]#items# property.
 Current selection is indicated by the [propertyname]#value# property.
 You can set or change the selection programmatically by setting the property value.
-Doing so also updates the visible fields."
+Doing so also updates the visible fields.
 
 [source,html]
 ----
-<vaadin-combo-box label='Element'></vaadin-combo-box>
+<vaadin-combo-box label="Element"></vaadin-combo-box>
 ----
 
 [source,javascript]
@@ -75,6 +75,39 @@ In addition to other features mentioned earlier, the [vaadinelement]#vaadin-comb
   form.addEventListener('iron-form-submit', function() {
     alert('Form submitted with name: ' + form.serialize().name);
     return false;
+  });
+</script>
+----
+
+== Custom Input Values
+
+Users can be allowed also to input their own custom values. By default, this feature is disabled, so it
+needs to be explicitly enabled.
+
+[source,html]
+----
+<vaadin-combo-box allow-custom-value></vaadin-combo-box>
+----
+
+When enabled, inputed custom values will be always set as the value of the [vaadinelement]#vaadin-combo-box#.
+If you need to prevent that from happening, you can provide your own handler for the custom values.
+
+[source,html]
+----
+<dom-module id="my-element">
+  <template>
+    <vaadin-combo-box id="combobox" on-custom-value="onCustomValue"></vaadin-combo-box>
+  </template>
+</dom-module>
+<script>
+  Polymer({
+    is: 'my-element',
+    onCustomValue: function(event) {
+      // Prevents the custom value to be assigned.
+      event.preventDefault();
+
+      this.$.combobox.value = 'Default Value';
+    }
   });
 </script>
 ----

--- a/docs/vaadin-combo-box-basic.adoc
+++ b/docs/vaadin-combo-box-basic.adoc
@@ -89,14 +89,15 @@ needs to be explicitly enabled.
 <vaadin-combo-box allow-custom-value></vaadin-combo-box>
 ----
 
-When enabled, inputed custom values will be always set as the value of the [vaadinelement]#vaadin-combo-box#.
-If you need to prevent that from happening, you can provide your own handler for the custom values.
+When enabled, custom input values are always accepted and used as the value of the [vaadinelement]#vaadin-combo-box#.
+If you need to cancel the automatic assignment, you can provide your own listener for the custom-value-set event
+that prevents the default behavior.
 
 [source,html]
 ----
 <dom-module id="my-element">
   <template>
-    <vaadin-combo-box id="combobox" on-custom-value="onCustomValue"></vaadin-combo-box>
+    <vaadin-combo-box id="combobox" on-custom-value-set="onCustomValue"></vaadin-combo-box>
   </template>
 </dom-module>
 <script>

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -34,6 +34,7 @@
 
       beforeEach(function() {
         comboBox = fixture('combobox');
+        comboBox.allowCustomValue = true;
       });
 
       it('should have the given name', function() {
@@ -74,6 +75,7 @@
         comboBox.required = true;
         expect(comboBox.validate()).to.equal(false);
         expect(comboBox.invalid).to.be.equal(true);
+
         comboBox.value = 'foo';
         expect(comboBox.validate()).to.equal(true);
         expect(comboBox.invalid).to.be.equal(false);

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -169,13 +169,23 @@
         expect(comboBox.value).to.eql('');
       });
 
-      it('should close the overlay with enter when input has a custom value', function() {
+      it('should close the overlay with enter when custom values are allowed', function() {
+        comboBox.allowCustomValue = true;
         filter('foobar');
 
         enter();
 
         expect(comboBox.value).to.equal('foobar');
         expect(comboBox.opened).to.equal(false);
+      });
+
+      it('should not close the overlay with enter when custom values are not allowed', function() {
+        filter('foobar');
+
+        enter();
+
+        expect(comboBox.value).to.equal('bar');
+        expect(comboBox.opened).to.equal(true);
       });
 
       it('should close the overlay with enter', function() {

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -142,6 +142,7 @@
     var combobox;
     beforeEach(function() {
       combobox = fixture('combobox');
+      combobox.allowCustomValue = true;
       combobox.items = ['foo', 'bar', 'barbar'];
 
       combobox.open();

--- a/test/vaadin-combo-box-properties.html
+++ b/test/vaadin-combo-box-properties.html
@@ -81,10 +81,10 @@
           expect(comboBox.value).to.eql('foo');
         });
 
-        describe('`custom-value` event', function() {
+        describe('`custom-value-set` event', function() {
           it('should be fired when custom value is set', function() {
             var spy = sinon.spy();
-            comboBox.addEventListener('custom-value', spy);
+            comboBox.addEventListener('custom-value-set', spy);
 
             comboBox.open();
             comboBox.$.input.bindValue = 'foo';
@@ -93,8 +93,21 @@
             expect(spy.callCount).to.eql(1);
           });
 
+          it('should not be fired when custom values are not allowed', function() {
+            comboBox.allowCustomValue = false;
+
+            var spy = sinon.spy();
+            comboBox.addEventListener('custom-value-set', spy);
+
+            comboBox.open();
+            comboBox.$.input.bindValue = 'foo';
+            comboBox.close();
+
+            expect(spy.callCount).to.eql(0);
+          });
+
           it('should be cancelable', function() {
-            comboBox.addEventListener('custom-value', function(e) {
+            comboBox.addEventListener('custom-value-set', function(e) {
               e.preventDefault();
             });
 

--- a/test/vaadin-combo-box-properties.html
+++ b/test/vaadin-combo-box-properties.html
@@ -62,6 +62,51 @@
         });
       });
 
+      describe('allow custom value property', function() {
+        beforeEach(function() {
+          comboBox.allowCustomValue = true;
+        });
+
+        it('should set bind value after setting value property', function() {
+          comboBox.value = 'foo';
+
+          expect(comboBox.$.input.bindValue).to.eql('foo');
+        });
+
+        it('should set value after setting a custom input value', function() {
+          comboBox.open();
+          comboBox.$.input.bindValue = 'foo';
+          comboBox.close();
+
+          expect(comboBox.value).to.eql('foo');
+        });
+
+        describe('`custom-value` event', function() {
+          it('should be fired when custom value is set', function() {
+            var spy = sinon.spy();
+            comboBox.addEventListener('custom-value', spy);
+
+            comboBox.open();
+            comboBox.$.input.bindValue = 'foo';
+            comboBox.close();
+
+            expect(spy.callCount).to.eql(1);
+          });
+
+          it('should be cancelable', function() {
+            comboBox.addEventListener('custom-value', function(e) {
+              e.preventDefault();
+            });
+
+            comboBox.open();
+            comboBox.$.input.bindValue = 'foo';
+            comboBox.close();
+
+            expect(combobox.value).to.be.empty;
+          });
+        });
+      });
+
       describe('label property', function() {
         it('should have undefined by default', function() {
           expect(comboBox.label).to.be.undefined;

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -122,6 +122,11 @@
         observer: '_focusedIndexChanged'
       },
 
+      _focusedItem: {
+        type: String,
+        computed: '_getFocusedItem(_focusedIndex)'
+      },
+
       _ariaActiveIndex: {
         type: Number,
         notify: true,
@@ -131,6 +136,12 @@
 
     ready: function() {
       this._patchWheelOverScrolling();
+    },
+
+    _getFocusedItem: function(focusedIndex) {
+      if (focusedIndex >= 0) {
+        return this._items[focusedIndex];
+      }
     },
 
     _isItemFocused: function(focusedIndex, itemIndex) {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -308,6 +308,8 @@ enable usage within an `iron-form`.
     },
 
     _onEnter: function(e) {
+      // should close on enter when custom values are allowed, input field is cleared, or when an existing
+      // item is focused with keyboard.
       if (this.opened && (this.allowCustomValue || this.$.input.bindValue === '' || this._focusedIndex > -1)) {
         this.close();
 
@@ -398,13 +400,13 @@ enable usage within an `iron-form`.
       } else if (this.$.input.bindValue === '') {
         this._clear();
       } else {
-        var e = this.fire('custom-value', this.$.input.bindValue, {cancelable: true});
-        if (!e.defaultPrevented) {
-          if (this.allowCustomValue) {
+        if (this.allowCustomValue) {
+          var e = this.fire('custom-value-set', this.$.input.bindValue, {cancelable: true});
+          if (!e.defaultPrevented) {
             this.value = this.$.input.bindValue;
-          } else {
-            this.$.input.bindValue = this.value;
           }
+        } else {
+          this.$.input.bindValue = this.value;
         }
       }
 

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -398,8 +398,8 @@ enable usage within an `iron-form`.
       } else if (this.$.input.bindValue === '') {
         this._clear();
       } else {
-        var e = this.fire('custom-value', this.$.input.bindValue, { cancelable: true });
-        if (!e.isDefaultPrevented) {
+        var e = this.fire('custom-value', this.$.input.bindValue, {cancelable: true});
+        if (!e.defaultPrevented) {
           if (this.allowCustomValue) {
             this.value = this.$.input.bindValue;
           } else {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -150,7 +150,6 @@ enable usage within an `iron-form`.
     <vaadin-combo-box-overlay
         id="overlay"
         _aria-active-index="{{_ariaActiveIndex}}"
-        _selected-item="{{_selectedItem}}"
         position-target="[[_positionTarget]]"
         _focused-index="[[_focusedIndex]]"
         on-down="_blurInput"
@@ -186,6 +185,14 @@ enable usage within an `iron-form`.
         type: String,
         observer: '_valueChanged',
         value: ''
+      },
+
+      /**
+       * If `true`, user can input a value that is not present in the items list.
+       */
+      allowCustomValue: {
+        type: Boolean,
+        value: false
       },
 
       /**
@@ -270,10 +277,7 @@ enable usage within an `iron-form`.
       if (this.opened) {
         if (this.$.overlay._items) {
           this._focusedIndex = Math.min(this.$.overlay._items.length - 1, this._focusedIndex + 1);
-          if (this._focusedIndex > -1) {
-            this.$.input.bindValue = this.$.overlay._items[this._focusedIndex];
-            this._setSelectionRange();
-          }
+          this._prefillFocusedItemLabel();
         }
       } else {
         this.open();
@@ -290,17 +294,21 @@ enable usage within an `iron-form`.
           }
         }
 
-        if (this._focusedIndex > -1) {
-          this.$.input.bindValue = this.$.overlay._items[this._focusedIndex];
-          this._setSelectionRange();
-        }
+        this._prefillFocusedItemLabel();
       } else {
         this.open();
       }
     },
 
+    _prefillFocusedItemLabel: function() {
+      if (this._focusedIndex > -1) {
+        this.$.input.bindValue = this.$.overlay._focusedItem;
+        this._setSelectionRange();
+      }
+    },
+
     _onEnter: function(e) {
-      if (this.opened) {
+      if (this.opened && (this.allowCustomValue || this.$.input.bindValue === '' || this._focusedIndex > -1)) {
         this.close();
 
         // Do not submit the surrounding form.
@@ -387,8 +395,17 @@ enable usage within an `iron-form`.
       if (this._focusedIndex > -1) {
         this.$.overlay._selectItem(this._focusedIndex);
         this.$.input.bindValue = this.value;
+      } else if (this.$.input.bindValue === '') {
+        this._clear();
       } else {
-        this.value = this.$.input.bindValue;
+        var e = this.fire('custom-value', this.$.input.bindValue, { cancelable: true });
+        if (!e.isDefaultPrevented) {
+          if (this.allowCustomValue) {
+            this.value = this.$.input.bindValue;
+          } else {
+            this.$.input.bindValue = this.value;
+          }
+        }
       }
 
       this._clearSelectionRange();
@@ -490,7 +507,7 @@ enable usage within an `iron-form`.
       if (this.$.overlay._items && value) {
         for (var i = 0; i < this.$.overlay._items.length; i++) {
           if (this.$.overlay._items[i].toString().toLowerCase() ===
-              this.$.input.bindValue.toString().toLowerCase()) {
+              value.toString().toLowerCase()) {
             return i;
           }
         }
@@ -502,7 +519,9 @@ enable usage within an `iron-form`.
     _selectedItemChanged: function(event, selectedItem) {
       if (selectedItem.value !== null) {
         this.value = selectedItem.value;
-      } else if (this.opened) {
+      }
+
+      if (this.opened) {
         this.close();
       }
     },


### PR DESCRIPTION
Fixes #154 

- Added `allow-custom-value` property which is `false` by default
- `custom-value` event is fired when a custom value is set

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/155)
<!-- Reviewable:end -->
