### PR TITLE
Force position:fixed for overlay when combo-box has fixed position.

### DIFF
--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -21,6 +21,16 @@
   </template>
 </test-fixture>
 
+<test-fixture id='fixed'>
+  <template>
+    <div style="position:fixed">
+      <div>
+        <vaadin-combo-box label='combobox' style='width: 300px;'></vaadin-combo-box>
+      </div>
+    </div>
+  </template>
+</test-fixture>
+
 <script>
   var comboBox;
 
@@ -109,6 +119,34 @@
 
         expect(dropContentRect().width).to.equal(inputContentRect().width);
       });
+    });
+  });
+
+  describe('overlay with fixed position target', function() {
+    function position(node) {
+      return window.getComputedStyle(node).position;
+    }
+
+    it('should same position when parent has fixed', function(done) {
+      var combobox = fixture('fixed').querySelector('vaadin-combo-box');
+
+      combobox.open();
+
+      Polymer.Base.async(function() {
+        expect(position(combobox.$.overlay)).to.eql('fixed');
+        done();
+      }, 1);
+    });
+
+    it('should have position absolute', function(done) {
+      var combobox = fixture('combobox');
+
+      combobox.open();
+
+      Polymer.Base.async(function() {
+        expect(position(combobox.$.overlay)).to.eql('absolute');
+        done();
+      }, 1);
     });
   });
 </script>

--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -34,6 +34,7 @@
 
     attached: function() {
       if (this.parentElement === document.body) {
+        this.style.position = this._isPositionFixed(this.positionTarget) ? 'fixed' : 'absolute';
         window.addEventListener('scroll', this._boundSetOverlayPosition, true);
         this._setOverlayPosition();
       }
@@ -41,6 +42,12 @@
 
     detached: function() {
       window.removeEventListener('scroll', this._boundSetOverlayPosition, true);
+    },
+
+    _isPositionFixed: function(element) {
+      var parentElement = element.parentElement || element.domHost;
+      return window.getComputedStyle(element).position === 'fixed' ||
+        (parentElement && this._isPositionFixed(parentElement));
     },
 
     _setOverlayPosition: function() {


### PR DESCRIPTION
Fixes #108 

This will mitigate both calculation differences between elements using fixed
vs. absolute, and iOS problems because of it is switching position between
fixed and absolute when input field is focused and blurred.

The problem became so obvious while testing #151 that decided to fix this now.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/158)
<!-- Reviewable:end -->
