### PR TITLE
Don't scroll to selected item when items are set

### DIFF
--- a/test/filtering.html
+++ b/test/filtering.html
@@ -108,6 +108,25 @@
       });
     });
 
+    describe('focusing items while filtering', function() {
+      it('should focus on an exact match', function() {
+        setInputValue('bar');
+
+        expect(comboBox._focusedIndex).to.eql(0);
+      });
+
+      it('should not scroll to selected value when filtering', function() {
+        comboBox.value = 'baz';
+
+        var spy = sinon.spy(comboBox.$.overlay, '_scrollIntoView');
+
+        setInputValue('ba');
+        setInputValue('b');
+
+        expect(spy.callCount).to.eql(0);
+      });
+    });
+
     describe('filtering items', function() {
       it('should filter items using contains', function() {
         setInputValue('a');

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -542,7 +542,7 @@ enable usage within an `iron-form`.
 
       if (this.$.overlay._items && this.$.overlay._items.indexOf(this.selectedItem) > -1) {
         this.$.overlay._selectItem(this.selectedItem);
-        this._focusedIndex = this.items.indexOf(this.selectedItem);
+        this._focusedIndex = -1;
       }
 
       this.$.overlay.hidden = (items === undefined || items === null || items.length === 0);


### PR DESCRIPTION
Fixes #166 

Calling scrollToIndex on iron-list while it is rendering the list causes
it sometimes to scroll in a totally wrong position, especially if the list
size changes. Scrolling is called because we try to focus the selected item
when items are set.

To fix the issue, instead of calling _scrollIntoView asyncronously, we can
actually remove the focusing when items are set. It is enough to set the focus
only when there is an exact match when filtering or when a value is set.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/167)
<!-- Reviewable:end -->
