### PR TITLE
Use scroll height to limit overlay height

### DIFF
--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -69,7 +69,7 @@
     _maxHeight: function(targetRect) {
       var margin = 8;
       var minHeight = 116; // Height of two items in combo-box
-      var bottom = Math.min(window.innerHeight, document.body.getBoundingClientRect().bottom);
+      var bottom = Math.min(window.innerHeight, document.body.scrollHeight - document.body.scrollTop);
 
       if (this._alignedAbove) {
         return Math.max(targetRect.top - margin, minHeight) + 'px';


### PR DESCRIPTION
Fixes #169 

Originally, plain window.innerHeight is not enough to determine the max-height
for the overlay, because Safari fires scroll events when overscrolling the
body which in turn makes window.innerHeight grow.

Instead, we need a hard limit at the bottom. Body scrollHeight doesnt change (that much)
when scrolling so it works nicely.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/175)
<!-- Reviewable:end -->
