### PR TITLE
Change toggle icon from arrow to menu

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -68,34 +68,33 @@ enable usage within an `iron-form`.
       position: relative;
       width: 24px;
       height: 24px;
+      text-align: center;
     }
 
     paper-input-container iron-icon {
       fill: rgba(0, 0, 0, .26);
       cursor: pointer;
-      padding: 0px;
-      --iron-icon-width: 24px;
-      --iron-icon-height: 24px;
-      transition: all .2s;
+      --iron-icon-width: 20px;
+      --iron-icon-height: 20px;
+      margin-top: -1px;
+      transition: fill 0.2s;
     }
 
     paper-input-container paper-ripple {
       color: rgba(0, 0, 0, .54);
     }
 
+    paper-input-container iron-icon:hover,
     paper-input-container[opened] iron-icon {
       fill: rgba(0, 0, 0, .54);
     }
 
-    paper-input-container[opened] #toggleIcon iron-icon {
-      transform: rotate(-180deg);
+    paper-input-container[opened] iron-icon:hover {
+      fill: rgba(0, 0, 0, .86);
     }
 
-    #clearIcon iron-icon {
-      padding-left: 2px;
-      padding-bottom: 2px;
-      --iron-icon-width: 20px;
-      --iron-icon-height: 20px;
+    #clearIcon {
+      margin-right: 4px;
     }
 
     #input::-ms-clear {
@@ -130,7 +129,7 @@ enable usage within an `iron-form`.
         <paper-ripple class="circle" center></paper-ripple>
       </div>
       <div suffix id="toggleIcon" on-tap="_toggle" on-touchend="_preventDefault" hidden$="[[_hideToggleIcon(disabled, readonly)]]">
-        <iron-icon icon="arrow-drop-down" aria-controls="overlay"></iron-icon>
+        <iron-icon icon="menu" aria-controls="overlay"></iron-icon>
         <paper-ripple class="circle" center></paper-ripple>
       </div>
     </paper-input-container>


### PR DESCRIPTION
Related to https://github.com/vaadin/components-team-tasks/issues/82

Small style fixes to both the toggle and clear icons and their ripples.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/176)
<!-- Reviewable:end -->
