### PR TITLE
Remove the style scope of combo-box from overlay when using Shadow DOM

### DIFF
--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -91,6 +91,21 @@
         expect(combobox.$.overlay.hidden).to.be.true;
       });
 
+      // When using Shadow DOM polyfill, the style scope of the combobox might
+      // not get removed from the overlay after it's moved to the body. The
+      // following test ensures that the overlay doesn't keep the style scope
+      // of the combobox when moved during open.
+      it('should not leak combobox style scope to the overlay', function() {
+        // Test only when style scope classes are used
+        if (combobox.$.overlay.classList.contains('style-scope') &&
+            combobox.$.overlay.classList.contains('vaadin-combo-box')) {
+          combobox.open();
+
+          expect(combobox.$.overlay.classList.contains('style-scope')).to.be.false;
+          expect(combobox.$.overlay.classList.contains('vaadin-combo-box')).to.be.false;
+        }
+      });
+
       describe('after opening', function() {
         beforeEach(function() {
           combobox.open();
@@ -181,6 +196,24 @@
           done();
         }, 1);
       });
+
+      // When using Shadow DOM polyfill, the style scope of the combobox might
+      // not get added to the overlay after it's moved back to the combobox.
+      // The following test ensures that the overlay doesn't keep the style
+      // scope of the combobox when moved during close.
+      it('should add combobox style scope to the overlay', function() {
+        // Test only when style scope classes are used
+        if (combobox.$.overlay.classList.contains('style-scope') &&
+            combobox.$.overlay.classList.contains('vaadin-combo-box')) {
+          combobox.open();
+
+          combobox.close();
+
+          expect(combobox.$.overlay.classList.contains('style-scope')).to.be.true;
+          expect(combobox.$.overlay.classList.contains('vaadin-combo-box')).to.be.true;
+        }
+      });
+
     });
 
     describe('disabled', function() {

--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -51,10 +51,20 @@
       // cancel each other. We need to process mutation observers synchonously after moving the overlay. :-(
       var oldParentNode = this.parentNode;
       Polymer.dom(target).appendChild(this);
+
       if (oldParentNode) {
         this._processPendingMutationObserversFor(oldParentNode);
+        if (oldParentNode.host) {
+          // When moving from local DOM, ensure to remove the old style scope
+          Polymer.StyleTransformer.dom(this, oldParentNode.host.is, this._scopeCssViaAttr, true);
+        }
       }
+
       this._processPendingMutationObserversFor(this);
+      if (target.host) {
+        // When moving to local DOM, ensure to add the new style scope
+        Polymer.StyleTransformer.dom(this, target.host.is, this._scopeCssViaAttr);
+      }
 
       if (target === document.body) {
         this.style.position = this._isPositionFixed(this.positionTarget) ? 'fixed' : 'absolute';


### PR DESCRIPTION
Fixes #118

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/211)
<!-- Reviewable:end -->