### PR TITLE
Force _scroller property to iron-list before attached called

### DIFF
--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -150,6 +150,12 @@
 
     ready: function() {
       this._patchWheelOverScrolling();
+
+      // Fix for #182. Only relevant for iron-list 1.0.X and 1.1.X.
+      // 1.2.X works fine without this.
+      if (this.$.selector._scroller !== undefined) {
+        this.$.selector._scroller = this._getScroller();
+      }
     },
 
     _getFocusedItem: function(focusedIndex) {


### PR DESCRIPTION
This avoids an exception when the combo-box value gets set before attached is called for the iron-list (which self-assigns _scroller).
Only relevant for iron-list 1.0.X and 1.1.X.

The fix can't be tested automatically as the test environment always installs latest iron-list version (which doesn't have the issue).

Fixes #182

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/213)
<!-- Reviewable:end -->