### PR TITLE
Don't blur the input field when closing dropdown on touch devices

### DIFF
--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -122,15 +122,6 @@
 
            expect(focusedInput).to.be.null;
           });
-
-          it('should blur input on close', function() {
-           combobox.$.input.focus();
-
-           combobox.close();
-
-           var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');
-           expect(focusedInput).to.be.null;
-          });
         } else if (!safari) { // TODO: Sauce Labs bug doesn't allow Safari in OS X to focus.
           it('should focus input on dropdown open', function() {
             var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');

--- a/vaadin-dropdown-behavior.html
+++ b/vaadin-dropdown-behavior.html
@@ -98,11 +98,6 @@
 
       this._removeOutsideClickListener();
 
-      // For touch devices, we want to hide the virtual keyboard after closing the overlay.
-      if (this.$.overlay.touchDevice) {
-        this.$.input.blur();
-      }
-
       this.fire('vaadin-dropdown-closed');
     },
 


### PR DESCRIPTION
Fixes #203

This change removes automatic input blur when closing the dropdown on touch devices, keeping blur on touch start in the overlay. 

- Tapping item in the overlay behaviour: the same as in master. This still blurs the input and hides the keyboard.
- Enter key behaviour: different. Previously it blurred the input on touch devices, now just selects the focused item and closes the overlay.
- Clicking the item with mouse: works the same as in master, blurs the input.

Since the enter key behaviour is different, it could be an UX regression. Did lightweight UX test with Denis on iPhone, findings:
- The most common way to select items on touch device is tapping the item, not the enter key. Even when virtual keyboard is inovolved in filtering the items.
- It's not required for the enter key to close the keyboard on touch device.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/214)
<!-- Reviewable:end -->