### PR TITLE
Enable momentum scrolling on iOS with iron-list v1.2+

### DIFF
--- a/test/scrolling.html
+++ b/test/scrolling.html
@@ -38,6 +38,14 @@
           expect(focusedInput).not.to.equal(combobox.$.input);
         });
       });
+
+      describeIf(ios, 'iOS', function() {
+        it('should have momentum scrolling enabled', function() {
+          combobox.open();
+
+          expect(getComputedStyle(unwrap(combobox.$.overlay.$.scroller)).WebkitOverflowScrolling).to.equal('touch');
+        });
+      });
     });
   </script>
 

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -31,6 +31,9 @@
 
       /* Fixes item background from getting on top of scrollbars on Safari */
       transform: translate3d(0,0,0);
+
+      /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
+      -webkit-overflow-scrolling: touch;
     }
 
     #selector {


### PR DESCRIPTION
When using iron-list v1.2+, momentum scrolling was missing on iOS. This PR brings it back.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/221)
<!-- Reviewable:end -->