### PR TITLE
Show clear icon on touch devices

### DIFF
--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -87,15 +87,14 @@
     describe('overlay position', function() {
       it('should match the input container width', function() {
         comboBox.open();
-        // Use floor values so that zooming in Chrome doesn't make the test fail
-        expect(~~(dropContentRect().width)).to.equal(~~(inputContentRect().width));
+
+        expect(dropContentRect().width).to.be.closeTo(inputContentRect().width, 1);
       });
 
       it('should be below the input box', function() {
         comboBox.open();
-        // Use floor values so that zooming in Chrome doesn't make the test fail
-        expect(~~(dropContentRect().top)).to.equal(
-          ~~(inputContentRect().bottom + comboBox.$.overlay.verticalOffset));
+
+        expect(dropContentRect().top).to.be.closeTo(inputContentRect().bottom + comboBox.$.overlay.verticalOffset, 1);
       });
 
       it('should position correctly if items are populated after opening', function(done) {
@@ -103,7 +102,7 @@
         comboBox.addEventListener('vaadin-dropdown-opened', function() {
           comboBox.items = [1, 2, 3];
           comboBox.async(function() {
-            expect(dropContentRect().top).to.equal(inputContentRect().bottom + comboBox.$.overlay.verticalOffset);
+            expect(dropContentRect().top).to.be.closeTo(inputContentRect().bottom + comboBox.$.overlay.verticalOffset, 1);
             done();
           }, 1);
         });
@@ -130,7 +129,7 @@
 
         expect(dropContentRect().left).to.equal(inputContentRect().left);
 
-        expect(dropContentRect().top).to.equal(inputContentRect().bottom + comboBox.$.overlay.verticalOffset);
+        expect(dropContentRect().top).to.be.closeTo(inputContentRect().bottom + comboBox.$.overlay.verticalOffset, 1);
       });
 
       it('when the input position width changes overlay width should change', function() {

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -88,21 +88,13 @@
       clearIcon = combobox.$.clearIcon;
     });
 
-    if (touchDevice) {
-      it('should not show the clearing icon for touch devices', function() {
-        combobox.open();
+    it('should show the clearing icon only when dropdown is open', function() {
+      expect(window.getComputedStyle(clearIcon).display).to.eql('none');
 
-        expect(window.getComputedStyle(clearIcon).display).to.eql('none');
-      });
-    } else {
-      it('should show the clearing icon only when dropdown is open', function() {
-        expect(window.getComputedStyle(clearIcon).display).to.eql('none');
+      combobox.open();
 
-        combobox.open();
-
-        expect(window.getComputedStyle(clearIcon).display).to.eql('block');
-      });
-    }
+      expect(window.getComputedStyle(clearIcon).display).to.eql('block');
+    });
 
     it('should not show clearing icon when nothing is selected', function() {
       combobox.open();

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -312,8 +312,10 @@
       var firstItemIndex = this.$.selector._physicalStart;
       var firstItemHeight = this.$.selector._physicalSizes[firstItemIndex];
 
-      if (firstItemHeight && this.$.selector._viewportSize) {
-        var visibleItems = (this.$.selector._viewportSize - this._viewportTotalPadding) / firstItemHeight;
+      var viewportHeight = this.$.selector._viewportHeight || this.$.selector._viewportSize; //Changed in v1.3.0.
+
+      if (firstItemHeight && viewportHeight) {
+        var visibleItems = (viewportHeight - this._viewportTotalPadding) / firstItemHeight;
         return Math.floor(visibleItems);
       }
     },

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -75,7 +75,7 @@ Custom property | Description | Default
     paper-input-container div[suffix] {
       position: absolute;
       bottom: -4px;
-      right: 0;
+      right: -4px;
 
       width: 24px;
       height: 24px;
@@ -106,7 +106,7 @@ Custom property | Description | Default
     }
 
     #clearIcon {
-      right: 32px;
+      right: 28px;
     }
 
     [hideclear] #clearIcon {
@@ -119,11 +119,11 @@ Custom property | Description | Default
 
     #input {
       box-sizing: border-box;
-      padding-right: 32px;
+      padding-right: 28px;
     }
 
     #inputContainer[opened]:not([hideclear]) #input {
-      padding-right: 64px;
+      padding-right: 60px;
       margin-right: -32px;
     }
 

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -73,9 +73,13 @@ Custom property | Description | Default
     }
 
     paper-input-container div[suffix] {
-      position: relative;
+      position: absolute;
+      bottom: -4px;
+      right: 0;
+
       width: 24px;
       height: 24px;
+      padding: 4px;
       text-align: center;
     }
 
@@ -102,11 +106,7 @@ Custom property | Description | Default
     }
 
     #clearIcon {
-      position: absolute;
-      right: 28px;
-      top: 0;
-      bottom: 0;
-      margin: auto;
+      right: 32px;
     }
 
     [hideclear] #clearIcon {
@@ -117,10 +117,14 @@ Custom property | Description | Default
       display: none;
     }
 
-    #inputContainer[opened]:not([hideclear]) #input {
+    #input {
       box-sizing: border-box;
-      padding-right: 30px;
-      margin-right: -30px;
+      padding-right: 32px;
+    }
+
+    #inputContainer[opened]:not([hideclear]) #input {
+      padding-right: 64px;
+      margin-right: -32px;
     }
 
   </style>
@@ -152,11 +156,11 @@ Custom property | Description | Default
           on-blur="_onBlur"
           on-tap="open"
           key-event-target>
-      <div suffix id="clearIcon" on-tap="_clear">
+      <div suffix id="clearIcon" on-tap="_clear" on-touchstart="_preventDefault">
         <iron-icon icon="clear"></iron-icon>
         <paper-ripple class="circle" center></paper-ripple>
       </div>
-      <div suffix id="toggleIcon" on-tap="_toggle" hidden$="[[_hideToggleIcon(disabled, readonly)]]">
+      <div suffix id="toggleIcon" on-tap="_toggle" hidden$="[[_hideToggleIcon(disabled, readonly)]]" on-touchstart="_preventDefault">
         <iron-icon icon="menu" aria-controls="overlay"></iron-icon>
         <paper-ripple class="circle" center></paper-ripple>
       </div>
@@ -620,7 +624,7 @@ Custom property | Description | Default
     },
 
     _hideClearIcon: function(value, opened) {
-      return this.$.overlay.touchDevice || value === '' || !opened;
+      return value === '' || !opened;
     },
 
     _hideToggleIcon: function(disabled, readonly) {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -156,11 +156,11 @@ Custom property | Description | Default
           on-blur="_onBlur"
           on-tap="open"
           key-event-target>
-      <div suffix id="clearIcon" on-tap="_clear" on-touchstart="_preventDefault">
+      <div suffix id="clearIcon" on-tap="_clear" on-touchend="_preventDefault">
         <iron-icon icon="clear"></iron-icon>
         <paper-ripple class="circle" center></paper-ripple>
       </div>
-      <div suffix id="toggleIcon" on-tap="_toggle" hidden$="[[_hideToggleIcon(disabled, readonly)]]" on-touchstart="_preventDefault">
+      <div suffix id="toggleIcon" on-tap="_toggle" hidden$="[[_hideToggleIcon(disabled, readonly)]]" on-touchend="_preventDefault">
         <iron-icon icon="menu" aria-controls="overlay"></iron-icon>
         <paper-ripple class="circle" center></paper-ripple>
       </div>


### PR DESCRIPTION
Fixes #197 

Made the icon touch area 32x32px and added some touchstart default action preventions to
prevent input field from focusing unintentionally when tapping on the icons.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/228)
<!-- Reviewable:end -->