### PR TITLE
Allow 'clear' to be disabled by adding a 'disable-clear' attribute.

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -293,6 +293,16 @@ Custom property | Description | Default
       itemValuePath: {
         type: String,
         value: 'value'
+      },
+
+      /**
+       * Disable the 'clear' button.
+       *
+       * With the attribute set, the clear button will be disabled.
+       */
+      disableClear: {
+        type: Boolean,
+        value: false
       }
     },
 
@@ -638,7 +648,7 @@ Custom property | Description | Default
     },
 
     _hideClearIcon: function(value, opened) {
-      return value === '' || !opened;
+      return this.disableClear || value === '' || !opened;
     },
 
     _hideToggleIcon: function(disabled, readonly) {


### PR DESCRIPTION
Simply adding a `disable-clear` attribute to the `<vaadin-combo-box>` component will disable the clear button (and functionally the clear functionality).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/244)
<!-- Reviewable:end -->
