### PR TITLE
If the component has a 'no-label-float' attribute, pass it on to paper-input

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -145,6 +145,7 @@ Custom property | Description | Default
         invalid="[[invalid]]"
         opened$="[[opened]]"
         hideclear$="[[_hideClearIcon(value, opened)]]"
+        no-label-float$="[[noLabelFloat]]"
         on-down="_preventDefault">
       <label id="label" on-tap="open">[[label]]</label>
       <input


### PR DESCRIPTION
If the `<vaadin-combo-box>` component has a `no-float-label` attribute, pass it on to `<paper-input-container>`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/245)
<!-- Reviewable:end -->
