### PR TITLE
Add a --vaadin-combo-box-overlay-item css mixin

### DIFF
--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -50,6 +50,8 @@
       white-space: nowrap;
       overflow: hidden;
       text-overflow: ellipsis;
+
+      @apply(--vaadin-combo-box-overlay-item);
     }
 
     #selector:not([touch-device]) .item:hover,


### PR DESCRIPTION
Add a --vaadin-combo-box-overlay-item css mixin to allow simple theme-based styling of combo-box items.

Example:

``` css
  vaadin-combo-box {
    --vaadin-combo-box-overlay-item: {
      padding: 0.5em;
    }
  }
```

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/246)

<!-- Reviewable:end -->
