### PR TITLE
Binds the noLabelFloat property to paper-input-container

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -145,7 +145,8 @@ Custom property | Description | Default
         invalid="[[invalid]]"
         opened$="[[opened]]"
         hideclear$="[[_hideClearIcon(value, opened)]]"
-        on-down="_preventDefault">
+        on-down="_preventDefault"
+        no-label-float$="[[noLabelFloat]]">
       <label id="label" on-tap="open">[[label]]</label>
       <input
           is="iron-input"
@@ -241,6 +242,11 @@ Custom property | Description | Default
       label: {
         type: String,
         reflectToAttribute: true
+      },
+      
+      noLabelFloat: {
+        type: Boolean,
+        value: false
       },
 
       _positionTarget: {


### PR DESCRIPTION
Binds the noLabelFloat property to paper-input-container, so that it is possible to disable the floating label, see https://elements.polymer-project.org/elements/paper-input#property-noLabelFloat

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/248)
<!-- Reviewable:end -->
