### PR TITLE
Fix the notifyPath call to have the explicit `undefined` value argument

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -580,7 +580,7 @@ Custom property | Description | Default
       //TODO: There is something wrong with observers and using set function
       // see here: https://github.com/Polymer/polymer/issues/3254
       //As a workaround setting/notifying the observer with the value undefined helps
-      this.$.overlay.notifyPath('_items');
+      this.$.overlay.notifyPath('_items', undefined);
       this.$.overlay.set('_items', items);
 
       var valueIndex = this._indexOfValue(this.value, items);


### PR DESCRIPTION
Fixes #250

The second and the third arguments in Polymer.Base.notifyPath are now optional since Polymer v1.5.0. Because of that, the behavior when called with a missing argument has changed. We have to use explicit `undefined` value argument from now on.

More about the change: https://github.com/Polymer/polymer/pull/3473

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/251)
<!-- Reviewable:end -->
