### PR TITLE
Fix/239

### DIFF
--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -36,19 +36,27 @@
     });
 
     describe('opening', function() {
-      it('should open by tapping label', function() {
+      it('should open asynchronously by tapping label', function(done) {
         Polymer.Base.fire('tap', {}, {
           bubbles: true,
           node: combobox.$$('paper-input-container label')
         });
 
-        expect(combobox.opened).to.be.true;
+        expect(combobox.opened).to.be.false;
+        Polymer.Base.async(function() {
+          expect(combobox.opened).to.be.true;
+          done();
+        }, 1);
       });
 
-      it('should open by clicking input', function() {
+      it('should open asynchronously by clicking input', function(done) {
         combobox.$$('paper-input-container input').fire('tap');
 
-        expect(combobox.opened).to.be.true;
+        expect(combobox.opened).to.be.false;
+        Polymer.Base.async(function() {
+          expect(combobox.opened).to.be.true;
+          done();
+        }, 1);
       });
 
       it('should open by clicking icon', function() {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -145,7 +145,7 @@ Custom property | Description | Default
         invalid="[[invalid]]"
         opened$="[[opened]]"
         hideclear$="[[_hideClearIcon(value, opened)]]">
-      <label id="label" on-tap="open">[[label]]</label>
+      <label id="label" on-tap="_openAsync">[[label]]</label>
       <input
           is="iron-input"
           id="input"
@@ -163,7 +163,7 @@ Custom property | Description | Default
           required$="[[required]]"
           on-input="_inputValueChanged"
           on-blur="_onBlur"
-          on-tap="open"
+          on-tap="_openAsync"
           key-event-target>
       <div suffix id="clearIcon" on-tap="_clear"
            on-down="_preventDefault">
@@ -433,6 +433,15 @@ Custom property | Description | Default
         this.$.input.blur();
         this._closeOnBlurIsPrevented = false;
       }
+    },
+
+    /**
+     * Opens the dropdown list asynchronously.
+     */
+    _openAsync: function() {
+      // Needed for MS Edge. Otherwise, it does not pop the virtual keyboard up
+      // when tapping the combobox that has non-empty value.
+      this.async(this.open);
     },
 
     /**

--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -108,7 +108,7 @@
 
     _setPosition: function(e) {
       var parent = this._unwrapIfNeeded(this.parentElement);
-      if ((!e || e.target.contains(this) || e.target.contains(this.positionTarget)) && parent === document.body) {
+      if ((!e || e.target.contains && (e.target.contains(this) || e.target.contains(this.positionTarget))) && parent === document.body) {
         var targetRect = this.positionTarget.getBoundingClientRect();
         this._alignedAbove = this._shouldAlignAbove();
 


### PR DESCRIPTION
Fixes #239

The change switches the opening of the combobox to be asynchronous when the user taps on the input field or on the label.

Makes MS Edge on Surface to always show the virtual keyboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/252)
<!-- Reviewable:end -->
