### PR TITLE
Enable JS indentation check and fix incorrect indentation

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -2,7 +2,6 @@
   "preset": "google",
   "maximumLineLength": 140,
   "disallowMultipleVarDecl": false,
-  "validateIndentation": false,
   "disallowTrailingWhitespace": false,
   "jsDoc": {
     "checkAnnotations": {

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -102,7 +102,8 @@ gulp.task('lint:html', function() {
         'test/*.html'
       ])
       .pipe(htmlExtract({
-        sel: 'script, code-example code'
+        sel: 'script, code-example code',
+        strip: true
       }))
       .pipe(jshint())
       .pipe(jshint.reporter())

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "chalk": "^1.1.1",
     "es6-shim": "^0.35.0",
     "gulp": "latest",
-    "gulp-html-extract": "0.0.3",
+    "gulp-html-extract": "^0.1.0",
     "gulp-jscs": "^3.0.2",
     "gulp-jshint": "^2.0.0",
     "gulp-sourcemaps": "^1.6.0",

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -156,15 +156,15 @@
     });
 
     it('should clear the selection when closing the overlay and input is cleared', function() {
-        combobox.value = 'foo';
+      combobox.value = 'foo';
 
-        combobox.$.input.bindValue = '';
-        combobox.$.input.fire('input');
+      combobox.$.input.bindValue = '';
+      combobox.$.input.fire('input');
 
-        combobox.close();
+      combobox.close();
 
-        expect(combobox.value).to.be.empty;
-        expect(combobox.$.overlay.$.selector.selectedItem).to.be.null;
+      expect(combobox.value).to.be.empty;
+      expect(combobox.$.overlay.$.selector.selectedItem).to.be.null;
     });
   });
 </script>

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -134,11 +134,11 @@
           });
 
           it('should not refocus the input field when closed from icon', function() {
-           tapToggleIcon();
+            tapToggleIcon();
 
-           var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');
+            var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');
 
-           expect(focusedInput).to.be.null;
+            expect(focusedInput).to.be.null;
           });
         } else if (!safari) { // TODO: Sauce Labs bug doesn't allow Safari in OS X to focus.
           it('should focus input on dropdown open', function() {
@@ -146,13 +146,13 @@
             expect(focusedInput).to.equal(combobox.$.input);
           });
 
-         it('should refocus the input field when closed from icon', function() {
-           tapToggleIcon();
+          it('should refocus the input field when closed from icon', function() {
+            tapToggleIcon();
 
-           var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');
+            var focusedInput = Polymer.dom(combobox.root).querySelector('input:focus');
 
-           expect(focusedInput).to.eql(combobox.$.input);
-         });
+            expect(focusedInput).to.eql(combobox.$.input);
+          });
         }
       });
     });
@@ -162,12 +162,12 @@
         it('should close popup when tapping outside overlay', function() {
           combobox.open();
 
-            Polymer.Base.fire('tap', {}, {
-              bubbles: true,
-              node: document.body
-            });
+          Polymer.Base.fire('tap', {}, {
+            bubbles: true,
+            node: document.body
+          });
 
-            expect(combobox.opened).to.be.false;
+          expect(combobox.opened).to.be.false;
         });
       } else {
         it('should close popup when clicking outside overlay', function() {

--- a/vaadin-dropdown-behavior.html
+++ b/vaadin-dropdown-behavior.html
@@ -134,11 +134,11 @@
 
     _removeOutsideClickListener: function() {
       if (this.$.overlay.touchDevice) {
-       // Not sure if this is a good idea to remove this Gesture globally, but that's how the iron-overlay-behavior does it.
-       Polymer.Gestures.remove(document, 'tap', null);
-       document.removeEventListener('tap', this._outsideClickListener.bind(this), true);
+        // Not sure if this is a good idea to remove this Gesture globally, but that's how the iron-overlay-behavior does it.
+        Polymer.Gestures.remove(document, 'tap', null);
+        document.removeEventListener('tap', this._outsideClickListener.bind(this), true);
       } else {
-       document.removeEventListener('click', this._outsideClickListener.bind(this), true);
+        document.removeEventListener('click', this._outsideClickListener.bind(this), true);
       }
     }
   };


### PR DESCRIPTION
Updating to a newer version of `gulp-html-extract` introduces a `strip` flag to remove extra indentation. This allows us to validate the indentation levels of JavaScript code embedded inside a `script` tag, which is enabled by this PR.

Also fixed some incorrect indentation that was found by enabling the check.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/264)
<!-- Reviewable:end -->
