### PR TITLE
Set inputElement to read-only to prevent angular2-polymer overriding …

### DIFF
--- a/test/angular2.html
+++ b/test/angular2.html
@@ -126,6 +126,10 @@
           it('should not reflect invalid state to combobox initially', function() {
             expect(combobox.invalid).to.be.false;
           });
+
+          it('should have a value set in inputElement', function() {
+            expect(combobox.inputElement).to.not.be.empty;
+          });
         });
 
         describe('after a value change', function() {

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -101,10 +101,13 @@
         value: 'value'
       },
 
-      // Keep the inputElement public, as vaadin-combo-box is extended with
-      // PaperInputBehavior, which already has "inputElement" defined and we
-      // don't want to have two separate properties.
-      inputElement: Object,
+      /**
+       * Returns a reference to the input element.
+       */
+      inputElement: {
+        type: HTMLElement,
+        readOnly: true
+      },
       _toggleElement: Object,
       _clearElement: Object,
 

--- a/vaadin-combo-box-light.html
+++ b/vaadin-combo-box-light.html
@@ -98,7 +98,7 @@ two `<paper-button>`s to act as the clear and toggle controls.
     },
 
     attached: function() {
-      this.inputElement = Polymer.dom(this).querySelector('input[is="iron-input"],paper-input,.paper-input-input,.input');
+      this._setInputElement(Polymer.dom(this).querySelector('input[is="iron-input"],paper-input,.paper-input-input,.input'));
       this._toggleElement = Polymer.dom(this).querySelector('.toggle-button');
       this._clearElement = Polymer.dom(this).querySelector('.clear-button');
 

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -326,7 +326,7 @@ Custom property | Description | Default
     },
 
     attached: function() {
-      this.inputElement = this.$.input;
+      this._setInputElement(this.$.input);
 
       // Use the default toggle/clear or one replaced in light DOM.
       this._toggleElement = Polymer.dom(this).querySelector('.toggle-button') || this.$.toggleIcon;


### PR DESCRIPTION
Fixes #280

Discussed also the options of setting the property with notify:true or making
it private, but decided to just make it readOnly as originally in the
PaperInputBehavior the property only has a getter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/281)
<!-- Reviewable:end -->
