### PR TITLE
Move icons 4px to left

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -74,7 +74,7 @@ Custom property | Description | Default
     :host ::content paper-icon-button.toggle-button {
       position: absolute;
       bottom: -4px;
-      right: -4px;
+      right: 0;
 
       line-height: 18px !important;
       width: 32px;
@@ -90,7 +90,7 @@ Custom property | Description | Default
 
     paper-input-container paper-icon-button.clear-button,
     paper-input-container ::content paper-icon-button.clear-button {
-      right: 28px;
+      right: 32px;
     }
 
     paper-input-container paper-icon-button:hover,
@@ -116,11 +116,11 @@ Custom property | Description | Default
 
     #input {
       box-sizing: border-box;
-      padding-right: 28px;
+      padding-right: 32px;
     }
 
     :host([opened][has-value]) #input {
-      padding-right: 60px;
+      padding-right: 64px;
       margin-right: -32px;
     }
 


### PR DESCRIPTION
Fixes #276

This PR effectively reverts d6e3edc in order to prevent a horizontal overflow, which might cause extra scrollbars in some situations (like described in #276).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/285)
<!-- Reviewable:end -->
