### PR TITLE
Prevent only mousedown events to not interfere with touch events

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -145,9 +145,6 @@
     },
 
     _onOverlayDown: function(event) {
-      // Prevent the focus transfer when user scrolls inside the overlay with mouse drag
-      event.preventDefault();
-
       if (this.$.overlay.touchDevice && event.target !== this.$.overlay.$.scroller) {
         // On touch devices, blur the input on touch start inside the overlay, in order to hide
         // the virtual keyboard. But don't close the overlay on this blur.

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -133,9 +133,8 @@ Custom property | Description | Default
           no-label-float="[[noLabelFloat]]"
           always-float-label="[[_computeAlwaysFloatLabel(alwaysFloatLabel,placeholder)]]"
           auto-validate$="[[autoValidate]]"
-          invalid="[[invalid]]"
-          on-down="_preventDefault">
-      <label id="label" hidden$="[[!label]]" aria-hidden="true" on-tap="_openAsync">[[label]]</label>
+          invalid="[[invalid]]">
+      <label on-down="_preventDefault" id="label" hidden$="[[!label]]" aria-hidden="true" on-tap="_openAsync">[[label]]</label>
 
       <content select="[prefix]"></content>
 
@@ -204,6 +203,7 @@ Custom property | Description | Default
         _focused-index="[[_focusedIndex]]"
         _item-label-path="[[itemLabelPath]]"
         on-down="_onOverlayDown"
+        on-mousedown="_preventDefault"
         vertical-offset="2">
     </vaadin-combo-box-overlay>
   </template>


### PR DESCRIPTION
Fixes #288 

Polymer 1.6.0 fixed `preventDefault` on `down` events that were originating from touch events (see https://github.com/Polymer/polymer/pull/3693). Our `vaadin-combo-box` accidentally relied on this bug.

After the update, focusing the input field and scrolling were both broken on touch devices. This PR attempts to resolve the problem by preventing only `mousedown` events.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/289)
<!-- Reviewable:end -->
