### PR TITLE
feat(combo): Handle multiple properties in combo box label

### DIFF
--- a/demo/object-items.html
+++ b/demo/object-items.html
@@ -230,6 +230,45 @@ layout: page
     </code-example>
   </section>
 
+
+  <section>
+    <h3>Custom Properties for Item Label and Value</h3>
+    <p>
+      You can override the default property paths by defining <code>item-label-path</code> and <code>item-value-path</code> properties.
+      <br/>
+      You can use several properties for the <code>item-label-path</code> concatened by <code>item-label-separator</code>
+    </p>
+
+    <code-example source>
+      <vaadin-combo-box demo class="elements-array-box" label="Element" item-label-separator=" - " item-label-path="symbol;name" item-value-path="symbol"></vaadin-combo-box>
+      <p>Selected element name: <span id="element-name"></span>.</p>
+      <p>Value: <span id="element-value"></span>.</p>
+
+      <code demo-var="combobox">
+        HTMLImports.whenReady(function() {
+        // code
+        var combobox = combobox || document.querySelector('.elements-array-box');
+
+        // elementsJson is an Array of Objects. Item object format:
+        //   {name: 'Hydrogen', symbol: 'H', number: 1}
+        combobox.items = elementsJson;
+
+        combobox.addEventListener('selected-item-changed', function() {
+        document.querySelector('#element-name').innerHTML = combobox.selectedItem && combobox.selectedItem.name;
+        });
+
+        combobox.addEventListener('value-changed', function() {
+        document.querySelector('#element-value').innerHTML = combobox.value;
+        });
+
+        combobox.value = 'C';
+        // end-code
+        });
+      </code>
+    </code-example>
+  </section>
+
+
 </body>
 
 </html>

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -89,6 +89,14 @@
       },
 
       /**
+       * Separator for the label of the item.
+       */
+      itemLabelSeparator : {
+        type: String,
+        value: ' '
+      },
+
+      /**
        * Path for the value of the item. If `items` is an array of objects, the
        * `itemValuePath:` is used to fetch the string value for the selected
        * item.

--- a/vaadin-combo-box-light.html
+++ b/vaadin-combo-box-light.html
@@ -61,6 +61,7 @@ two `<paper-button>`s to act as the clear and toggle controls.
         _aria-active-index="{{_ariaActiveIndex}}"
         position-target="[[inputElement]]"
         _focused-index="[[_focusedIndex]]"
+        _item-label-separator="[[itemLabelSeparator]]"
         _item-label-path="[[itemLabelPath]]"
         on-down="_onOverlayDown"
         vertical-offset="[[overlayVerticalOffset]]">

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -147,6 +147,11 @@
         value: 'label'
       },
 
+      _itemLabelSeparator: {
+        type: String,
+        value: ' '
+      },
+
       _itemValuePath: {
         type: String,
         value: 'value'
@@ -190,9 +195,22 @@
      * Gets the label string for the item based on the `_itemLabelPath`.
      * @return {String}
      */
-    getItemLabel: function(item) {
-      var label = this.get(this._itemLabelPath, item);
-      if (label === undefined || label === null) {
+    getItemLabel: function (item) {
+      let label = '';
+      if (this._itemLabelPath !== undefined && this._itemLabelPath != null) {
+        let labelArray = this._itemLabelPath.split(';');
+        let labelArrayLength = labelArray.length;
+        for (let i = 0; i < labelArrayLength; i++) {
+          let lab = this.get(labelArray[i], item);
+          if (lab !== undefined && lab != null) {
+            label += lab;
+            if(i < labelArrayLength - 1) {
+              label += this._itemLabelSeparator;
+            }
+          }
+        }
+      }
+      if (label === '') {
         label = item ? item.toString() : '';
       }
       return label;

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -201,6 +201,7 @@ Custom property | Description | Default
         _aria-active-index="{{_ariaActiveIndex}}"
         position-target="[[_getPositionTarget()]]"
         _focused-index="[[_focusedIndex]]"
+        _item-label-separator="[[itemLabelSeparator]]"
         _item-label-path="[[itemLabelPath]]"
         on-down="_onOverlayDown"
         on-mousedown="_preventDefault"


### PR DESCRIPTION
This branch allows to handle both single and multiple properties in combo box label.
Very interested in using "custom properties for item label and value", I added multiple label properties support.

As you can see in the demo file, you can now use several properties for the label of the combo as follows : 
`item-label-path="name"`

You can even specify a separator between the desired values as follows : 
`item-label-separator=" - "`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/300)
<!-- Reviewable:end -->
