### PR TITLE
Fix vaadin-combo-box compatibility with iron-list 1.3.9

### DIFF
--- a/test/aria.html
+++ b/test/aria.html
@@ -86,15 +86,18 @@
         arrowDown();
       });
 
-      it('should set selection aria attributes when focusing an item', function() {
+      it('should set selection aria attributes when focusing an item', function(done) {
         getSelector().selectedItem = 'foo';
         arrowDown();
 
-        expect(getItemElement(0).getAttribute('role')).to.equal('option');
-        expect(getItemElement(0).getAttribute('aria-selected')).to.equal('true');
-        expect(getItemElement(1).getAttribute('aria-selected')).to.equal('false');
-        expect(getInput().getAttribute('aria-activedescendant')).to.equal('it0');
-        expect(comboBox.$.overlay.$.selector.getAttribute('data-selection')).to.equal('it0');
+        Polymer.Base.async(function() {
+          expect(getItemElement(0).getAttribute('role')).to.equal('option');
+          expect(getItemElement(0).getAttribute('aria-selected')).to.equal('true');
+          expect(getItemElement(1).getAttribute('aria-selected')).to.equal('false');
+          expect(getInput().getAttribute('aria-activedescendant')).to.equal('it0');
+          expect(comboBox.$.overlay.$.selector.getAttribute('data-selection')).to.equal('it0');
+          done();
+        }, 100);
 
       });
     });

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -115,7 +115,7 @@
       it('should not scroll to selected value when filtering', function() {
         comboBox.value = 'baz';
 
-        var spy = sinon.spy(comboBox.$.overlay, '_scrollIntoView');
+        var spy = sinon.spy(comboBox.$.overlay, 'adjustScrollPosition');
 
         setInputValue('ba');
         setInputValue('b');

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -320,7 +320,7 @@
           expect(comboBox.$.overlay._visibleItemsCount()).to.eql(4);
           expect(comboBox.$.overlay._lastVisibleIndex()).to.eql(3);
           done();
-        });
+        }, 40);
       });
 
       it('should calculate items correctly when some items are hidden', function(done) {
@@ -336,12 +336,13 @@
         Polymer.Base.async(function() {
           expect(comboBox.$.overlay._lastVisibleIndex()).to.eql(comboBox.$.overlay._visibleItemsCount() - 1);
           done();
-        });
+        }, 40);
       });
     });
 
     describe('scrolling items', function() {
       var selector;
+      var asyncDelay = 100;
 
       beforeEach(function(done) {
         var items = [];
@@ -354,64 +355,76 @@
         comboBox.open();
         selector = comboBox.$.overlay.$.selector;
 
-        Polymer.Base.async(done);
+        Polymer.Base.async(done, asyncDelay);
       });
 
-      it('should scroll down after reaching the last visible item', function() {
+      it('should scroll down after reaching the last visible item', function(done) {
         comboBox._focusedIndex = comboBox.$.overlay._visibleItemsCount() - 1;
         expect(selector.firstVisibleIndex).to.eql(0);
 
         arrowDown();
-
-        expect(selector.firstVisibleIndex).to.eql(1);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(1);
+          done();
+        }, asyncDelay);
       });
 
-      it('should scroll up after reaching the first visible item', function() {
+      it('should scroll up after reaching the first visible item', function(done) {
         comboBox._focusedIndex = 1;
         selector.scrollToIndex(1);
         expect(selector.firstVisibleIndex).to.eql(1);
 
         arrowUp();
-
-        expect(selector.firstVisibleIndex).to.eql(0);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(0);
+          done();
+        }, asyncDelay);
       });
 
-      it('should scroll to first visible when navigating down above viewport', function() {
+      it('should scroll to first visible when navigating down above viewport', function(done) {
         comboBox._focusedIndex = 5;
         selector.scrollToIndex(50);
 
         arrowDown();
-
-        expect(selector.firstVisibleIndex).to.eql(6);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(6);
+          done();
+        }, asyncDelay);
       });
 
-      it('should scroll to first visible when navigating up above viewport', function() {
+      it('should scroll to first visible when navigating up above viewport', function(done) {
         comboBox._focusedIndex = 5;
         selector.scrollToIndex(50);
 
         arrowUp();
-
-        expect(selector.firstVisibleIndex).to.eql(4);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(4);
+          done();
+        }, asyncDelay);
       });
 
-      it('should scroll to last visible when navigating up below viewport', function() {
+      it('should scroll to last visible when navigating up below viewport', function(done) {
         comboBox._focusedIndex = 50;
         selector.scrollToIndex(0);
         expect(selector.firstVisibleIndex).to.eql(0);
 
         arrowUp();
-
-        expect(selector.firstVisibleIndex).to.eql(49 - comboBox.$.overlay._visibleItemsCount() + 1);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(49 - comboBox.$.overlay._visibleItemsCount() + 1);
+          done();
+        }, asyncDelay);
       });
 
-      it('should scroll to last visible when navigating down below viewport', function() {
+      it('should scroll to last visible when navigating down below viewport', function(done) {
         comboBox._focusedIndex = 50;
         selector.scrollToIndex(0);
         expect(selector.firstVisibleIndex).to.eql(0);
 
         arrowDown();
-
-        expect(selector.firstVisibleIndex).to.eql(51 - comboBox.$.overlay._visibleItemsCount() + 1);
+        Polymer.Base.async(function() {
+          expect(selector.firstVisibleIndex).to.eql(51 - comboBox.$.overlay._visibleItemsCount() + 1);
+          done();
+        }, asyncDelay);
       });
 
       it('should scroll to start if no items focused when opening overlay', function(done) {
@@ -423,7 +436,7 @@
         Polymer.Base.async(function() {
           expect(selector.firstVisibleIndex).to.eql(0);
           done();
-        });
+        }, asyncDelay);
       });
 
       it('should scroll to focused item when opening overlay', function(done) {
@@ -436,7 +449,7 @@
         Polymer.Base.async(function() {
           expect(selector.firstVisibleIndex).to.be.within(50 - comboBox.$.overlay._visibleItemsCount(), 50);
           done();
-        });
+        }, asyncDelay);
       });
     });
   });

--- a/test/scrolling.html
+++ b/test/scrolling.html
@@ -84,21 +84,30 @@
           expect(selectedItemRect.bottom).to.be.at.most(overlayRect.bottom);
         }
 
-        it('should make selected item visible after open', function() {
+        it('should make selected item visible after open', function(done) {
           combobox.value = combobox.items[50];
-          combobox.open();
 
-          expectSelectedItemPositionToBeVisible();
+          Polymer.Base.async(function() {
+            combobox.open();
+          }, 10);
+          Polymer.Base.async(function() {
+            expectSelectedItemPositionToBeVisible();
+            done();
+          }, 40);
         });
 
-        it('should make selected item visible after reopen', function() {
+        it('should make selected item visible after reopen', function(done) {
           combobox.open();
 
           combobox.value = combobox.items[50];
-          combobox.close();
-          combobox.open();
-
-          expectSelectedItemPositionToBeVisible();
+          Polymer.Base.async(function() {
+            combobox.close();
+            combobox.open();
+          }, 10);
+          Polymer.Base.async(function() {
+            expectSelectedItemPositionToBeVisible();
+            done();
+          }, 40);
         });
       });
     });

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -51,6 +51,7 @@
       it('should use the default label property in overlay items', function(done) {
         combobox.open();
 
+        combobox.$.overlay.$.selector.flushDebouncer('_debounceTemplate');
         Polymer.Base.async(function() {
           expect(combobox.$.overlay.$.selector.querySelector('.item').textContent).to.contain('foo');
           done();

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -163,6 +163,11 @@
       }
     },
 
+    attached: function() {
+      // Required after asynchrony introduced by iron-list 1.3.9.
+      this.async(this.$.selector.notifyResize, 10);
+    },
+
     _getFocusedItem: function(focusedIndex) {
       if (focusedIndex >= 0) {
         return this._items[focusedIndex];
@@ -251,7 +256,11 @@
 
     adjustScrollPosition: function() {
       if (this._items) {
-        this._scrollIntoView(this._focusedIndex);
+        // This must be async from iron-list 1.3.9 onwards to have the overlay
+        // visible before scrolling.
+        this.async(function() {
+          this._scrollIntoView(this._focusedIndex);
+        }, 1);
       }
     },
 


### PR DESCRIPTION
Fixes #304

The latest `iron-list` (v1.3.9) introduced more asynchrony to the initial rendering in order to improve performance. This broke a lot of our tests and also introduced two bugs (see #304).

This PR attempts to resolve the problems by adding an asynchronous `notifyResize` call to the `attached` callback of the overlay also wrapping `_scrollIntoView` call into an `async` callback. Not very nice things to do, but resolves the two bugs.

Also tests have been modified to work with these changes and the asynchrony introduced by `iron-list` update.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/305)
<!-- Reviewable:end -->