### PR TITLE
Ensure iron-list renders items synchronously on open

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -314,6 +314,12 @@
 
     _onOpened: function() {
       this.$.overlay.hidden = !this._hasItems(this.$.overlay._items);
+
+      // With iron-list v1.3.9, calling `notifyResize()` no longer renders
+      // the items synchonously. It is required to have the items rendered
+      // before we update the overlay and the list positions and sizes.
+      this.$.overlay.ensureItemsRendered();
+
       this.$.overlay.notifyResize();
       this.$.overlay.adjustScrollPosition();
     },

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -249,6 +249,10 @@
       this.$.selector.scrollToIndex(Math.max(0, targetIndex));
     },
 
+    ensureItemsRendered: function() {
+      this.$.selector._render && this.$.selector._render();
+    },
+
     adjustScrollPosition: function() {
       if (this._items) {
         this._scrollIntoView(this._focusedIndex);


### PR DESCRIPTION
Fixes #304 

Alternative for PR #305.

When combo-box opens, the combo-box-overlay needs `<iron-list>` to render the items, then updates its position and scrolls the list. Unfortunately, in v1.3.9 of `<iron-list>`, the items are rendered asynchronously on the next frames. At the same time, it’s impossible to make the overlay position and the list scroll position correct until the items are rendered.

Within this change, the combo-box-overlay manually calls synchronous render in `<iron-list>` on open, then the position and scroll are also updated in sync. This is different from the solution in #305, where the overlay waits for the asynchronous rendering of the items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/307)
<!-- Reviewable:end -->
