### PR TITLE
Stop tap event from bubbling outside the overlay

### DIFF
--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -38,6 +38,16 @@
       combobox.addEventListener('selected-item-changed', selectedItemChangedSpy);
     });
 
+    it('should stop tap events from bubbling outside the overlay', function() {
+      var tapSpy = sinon.spy();
+      document.addEventListener('tap', tapSpy);
+      combobox.$.overlay.$.selector.dispatchEvent(new CustomEvent('tap', {
+        bubbles: true
+      }));
+      document.removeEventListener('tap', tapSpy);
+      expect(tapSpy.called).not.to.be.true;
+    });
+
     it('should select by using the selector', function() {
       selector.selectedItem = 'foo';
       expect(combobox.value).to.equal('foo');

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -63,7 +63,7 @@
   </style>
 
   <template>
-    <div id="scroller" scroller="[[_getScroller()]]">
+    <div id="scroller" scroller="[[_getScroller()]]" on-tap="_stopPropagation">
       <iron-list
           id="selector"
           touch-device$="[[touchDevice]]"
@@ -339,6 +339,10 @@
 
     _preventDefault: function(e) {
       e.preventDefault();
+    },
+
+    _stopPropagation: function(e) {
+      e.stopPropagation();
     }
   });
 </script>


### PR DESCRIPTION
Having a `vaadin-combo-box` inside `iron-dropdown` (for example) causes the `iron-dropdown` to close whenever user selects an item from the `vaadin-combo-box` by tapping (on mobile devices).

This happens because the `vaadin-combo-box`'s dropdown overlay actually exists outside the `iron-dropdown`'s overlay and any tap event outside of it makes it close by default.

This PR makes the overlay stop any tap-events from propagating outside

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/311)
<!-- Reviewable:end -->
