### PR TITLE
Replace document with document.body when setting position

### DIFF
--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -139,6 +139,15 @@
         expect(spy.called).to.be.true;
       });
 
+      it('should reposition on scroll', function() {
+        comboBox.opened = true;
+        comboBox.$.overlay.updateViewportBoundaries = sinon.spy();
+
+        comboBox.fire('scroll', {}, {node: document});
+
+        expect(comboBox.$.overlay.updateViewportBoundaries.callCount).to.eql(1);
+      }),
+
       it('should be aligned with input container', function() {
         comboBox.open();
 

--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -108,31 +108,36 @@
     },
 
     _setPosition: function(e) {
-      var parent = this._unwrapIfNeeded(this.parentElement);
-      if ((!e || e.target.contains && (e.target.contains(this) || e.target.contains(this.positionTarget))) && parent === document.body) {
-        var targetRect = this.positionTarget.getBoundingClientRect();
-        this._alignedAbove = this._shouldAlignAbove();
-
-        // overlay max height is restrained by the #scroller max height which is set to 65vh in CSS.
-        this.style.maxHeight = this._maxHeight(targetRect);
-
-        // we need to set height for iron-list to make its `firstVisibleIndex` work correctly.
-        this.$.selector.style.maxHeight = this._maxHeight(targetRect);
-
-        var overlayRect = this.getBoundingClientRect();
-        this._translateX = targetRect.left - overlayRect.left + (this._translateX || 0);
-        this._translateY = targetRect.top - overlayRect.top + (this._translateY || 0) +
-          this._verticalOffset(overlayRect, targetRect);
-
-        var _devicePixelRatio = window.devicePixelRatio || 1;
-        this._translateX = Math.round(this._translateX * _devicePixelRatio) / _devicePixelRatio;
-        this._translateY = Math.round(this._translateY * _devicePixelRatio) / _devicePixelRatio;
-        this.translate3d(this._translateX + 'px', this._translateY + 'px', '0');
-
-        this.style.width = this.positionTarget.clientWidth + 'px';
-
-        this.updateViewportBoundaries();
+      if (e && e.target) {
+        var target = e.target === document ? document.body : e.target;
+        var parent = this._unwrapIfNeeded(this.parentElement);
+        if (!(target.contains(this) || target.contains(this.positionTarget)) || parent !== document.body) {
+          return;
+        }
       }
+
+      var targetRect = this.positionTarget.getBoundingClientRect();
+      this._alignedAbove = this._shouldAlignAbove();
+
+      // overlay max height is restrained by the #scroller max height which is set to 65vh in CSS.
+      this.style.maxHeight = this._maxHeight(targetRect);
+
+      // we need to set height for iron-list to make its `firstVisibleIndex` work correctly.
+      this.$.selector.style.maxHeight = this._maxHeight(targetRect);
+
+      var overlayRect = this.getBoundingClientRect();
+      this._translateX = targetRect.left - overlayRect.left + (this._translateX || 0);
+      this._translateY = targetRect.top - overlayRect.top + (this._translateY || 0) +
+        this._verticalOffset(overlayRect, targetRect);
+
+      var _devicePixelRatio = window.devicePixelRatio || 1;
+      this._translateX = Math.round(this._translateX * _devicePixelRatio) / _devicePixelRatio;
+      this._translateY = Math.round(this._translateY * _devicePixelRatio) / _devicePixelRatio;
+      this.translate3d(this._translateX + 'px', this._translateY + 'px', '0');
+
+      this.style.width = this.positionTarget.clientWidth + 'px';
+
+      this.updateViewportBoundaries();
     },
 
     _shouldAlignAbove: function() {


### PR DESCRIPTION
Fixes #318 

IE11 doesn't support contains method on document node.

(most of the changes are because of indentation change)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/319)
<!-- Reviewable:end -->
