### PR TITLE
Fix a null reference when filter is null 

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -439,7 +439,7 @@
       }
 
       return arr.filter((function(item) {
-        filter = filter.toString().toLowerCase() || '';
+        filter = filter ? filter.toString().toLowerCase() : '';
 
         // Check if item contains input value.
         return this._getItemLabel(item).toString().toLowerCase()


### PR DESCRIPTION
Fix a null reference when filter is null in certain conditions in vaadin-combo-box-light.

Fixes #323.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/324)
<!-- Reviewable:end -->
