### PR TITLE
Improve screen readers support

### DIFF
--- a/test/aria.html
+++ b/test/aria.html
@@ -15,7 +15,7 @@
 
 <test-fixture id='combobox'>
   <template>
-    <vaadin-combo-box></vaadin-combo-box>
+    <vaadin-combo-box label="my label"></vaadin-combo-box>
   </template>
 </test-fixture>
 
@@ -29,6 +29,12 @@
     }
     function getLabel() {
       return comboBox.$.label;
+    }
+    function getToggleIcon() {
+      return comboBox.$.toggleIcon;
+    }
+    function getClearIcon() {
+      return comboBox.$.clearIcon;
     }
     function getSelector() {
       return comboBox.$.overlay.$.selector;
@@ -55,9 +61,12 @@
     describe('when combo-box is attached', function() {
       it('should contain appropriate aria attributes', function() {
         expect(getInput().getAttribute('role')).to.equal('combobox');
-        expect(getInput().getAttribute('aria-labelledby')).to.equal('label');
+        expect(getInput().getAttribute('aria-label')).to.equal('my label');
         expect(getInput().getAttribute('aria-autocomplete')).to.equal('list');
-        expect(getInput().getAttribute('aria-owns')).to.equal('overlay');
+        expect(getToggleIcon().getAttribute('role')).to.equal('button');
+        expect(getToggleIcon().getAttribute('aria-label')).to.equal('Toggle');
+        expect(getClearIcon().getAttribute('role')).to.equal('button');
+        expect(getClearIcon().getAttribute('aria-label')).to.equal('Clear');
       });
     });
 
@@ -72,12 +81,14 @@
 
       it('should set aria-expanded attribute when opened', function() {
         expect(getInput().getAttribute('aria-expanded')).to.equal('true');
+        expect(getToggleIcon().getAttribute('aria-expanded')).to.equal('true');
       });
 
       it('should unset aria-expanded attribute when closed', function() {
         esc();
 
         expect(getInput().getAttribute('aria-expanded')).to.equal('false');
+        expect(getToggleIcon().getAttribute('aria-expanded')).to.equal('false');
       });
     });
 
@@ -93,9 +104,36 @@
         expect(getItemElement(0).getAttribute('role')).to.equal('option');
         expect(getItemElement(0).getAttribute('aria-selected')).to.equal('true');
         expect(getItemElement(1).getAttribute('aria-selected')).to.equal('false');
-        expect(getInput().getAttribute('aria-activedescendant')).to.equal('it0');
-        expect(comboBox.$.overlay.$.selector.getAttribute('data-selection')).to.equal('it0');
+      });
 
+      it('should change the input value with atomic change', function(done) {
+        getSelector().selectedItem = 'foo';
+
+        getInput().addEventListener('bind-value-changed', function() {
+          expect(getInput().getAttribute('aria-atomic')).to.equal('true');
+          done();
+        });
+
+        arrowDown();
+        arrowDown();
+      });
+
+      it('should preserve aria-atomic attribute in the input', function() {
+        getInput().setAttribute('aria-atomic', 'false');
+
+        getSelector().selectedItem = 'foo';
+        arrowDown();
+        arrowDown();
+
+        expect(getInput().getAttribute('aria-atomic')).to.equal('false');
+      });
+
+      it('should clean-up aria-atomic attribute in the input if was not set', function() {
+        getSelector().selectedItem = 'foo';
+        arrowDown();
+        arrowDown();
+
+        expect(getInput().hasAttribute('aria-atomic')).to.be.false;
       });
     });
 

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -240,8 +240,19 @@
 
     _prefillFocusedItemLabel: function() {
       if (this._focusedIndex > -1) {
-        this._inputElementValue = this._getItemLabel(this.$.overlay._focusedItem);
+        // Temporarily set aria-atomic="true" to prevent partial value changes
+        // announce. Makes OSX VoiceOver to announce the complete value instead.
+        var oldAriaAtomic = this.inputElement.getAttribute('aria-atomic');
+        this.inputElement.setAttribute('aria-atomic', true);
+
+        this._inputElementValue =  this._getItemLabel(this.$.overlay._focusedItem);
         this._setSelectionRange();
+
+        if (oldAriaAtomic !== null) {
+          this.inputElement.setAttribute('aria-atomic', oldAriaAtomic);
+        } else {
+          this.inputElement.removeAttribute('aria-atomic');
+        }
       }
     },
 

--- a/vaadin-combo-box-light.html
+++ b/vaadin-combo-box-light.html
@@ -59,7 +59,6 @@ two `<paper-button>`s to act as the clear and toggle controls.
 
     <vaadin-combo-box-overlay
         id="overlay"
-        _aria-active-index="{{_ariaActiveIndex}}"
         position-target="[[inputElement]]"
         _focused-index="[[_focusedIndex]]"
         _item-label-path="[[itemLabelPath]]"

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -68,7 +68,6 @@
           id="selector"
           touch-device$="[[touchDevice]]"
           role="listbox"
-          data-selection$="[[_ariaActiveIndex]]"
           on-touchend="_preventDefault"
           selected-item="{{_selectedItem}}"
           items="[[_items]]"
@@ -76,12 +75,11 @@
           scroll-target="[[_getScroller()]]">
         <template>
           <div class="item"
-              id$="it[[index]]"
               selected$="[[selected]]"
               role$="[[_getAriaRole(index)]]"
               aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
               focused$="[[_isItemFocused(_focusedIndex,index)]]">
-              [[getItemLabel(item)]]
+            [[getItemLabel(item)]]
           </div>
         </template>
       </iron-list>
@@ -134,12 +132,6 @@
       _focusedItem: {
         type: String,
         computed: '_getFocusedItem(_focusedIndex)'
-      },
-
-      _ariaActiveIndex: {
-        type: Number,
-        notify: true,
-        computed: '_getAriaActiveIndex(_focusedIndex)'
       },
 
       _itemLabelPath: {
@@ -200,14 +192,6 @@
 
     _isItemFocused: function(focusedIndex, itemIndex) {
       return focusedIndex == itemIndex;
-    },
-
-    _getAriaActiveIndex: function(focusedIndex) {
-      if (focusedIndex >= 0) {
-        return 'it' + focusedIndex;
-      }
-
-      return false;
     },
 
     _getAriaSelected: function(focusedIndex, itemIndex) {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -145,11 +145,9 @@ Custom property | Description | Default
           autocomplete="off"
           autocapitalize="none"
           bind-value="{{_inputElementValue}}"
-          aria-labelledby="label"
-          aria-activedescendant$="[[_ariaActiveIndex]]"
+          aria-label$="[[label]]"
           aria-expanded$="[[_getAriaExpanded(opened)]]"
           aria-autocomplete="list"
-          aria-owns="overlay"
           disabled$="[[disabled]]"
           invalid="{{invalid}}"
           prevent-invalid-input="[[preventInvalidInput]]"
@@ -173,6 +171,7 @@ Custom property | Description | Default
         <paper-icon-button
             id="clearIcon"
             tabindex="-1"
+            aria-label="Clear"
             icon="vaadin-combo-box:clear"
             on-down="_preventDefault"
             class="clear-button small">
@@ -184,7 +183,8 @@ Custom property | Description | Default
             id="toggleIcon"
             tabindex="-1"
             icon="vaadin-combo-box:arrow-drop-down"
-            aria-controls="overlay"
+            aria-label="Toggle"
+            aria-expanded$="[[_getAriaExpanded(opened)]]"
             on-down="_preventDefault"
             class="toggle-button rotate-on-open">
         </paper-icon-button>
@@ -197,7 +197,6 @@ Custom property | Description | Default
 
     <vaadin-combo-box-overlay
         id="overlay"
-        _aria-active-index="{{_ariaActiveIndex}}"
         position-target="[[_getPositionTarget()]]"
         _focused-index="[[_focusedIndex]]"
         _item-label-path="[[itemLabelPath]]"


### PR DESCRIPTION
Fixes #312

Changes:

  - Remove all aria attributes referencing IDs (`aria-activedescendant`,
    `aria-labelledby`, `aria-owns`, ...) for fostering simplicity.

    To use correctly we need to generate unique IDs in the document
    scope for everything we reference. Otherwise they might mix up and
    start to reference wrong things. Therefore, it is better to avoid ID
    referencing as much as possible. Verifying with VoiceOver / NVDA /
    JAWS has not revealed any drawbacks in screen reader user
    experience.

  - Use label property binding with `aria-label$="[[label]]"` instead of
    referencing the label element ID in `aria-labelledby`.

  - Give labels on the toggle and the clear icon buttons.

  - Announce full input value when prefilling the input for a selected
    item. Makes OS X VoiceOver not to announce nonsense half-word
    partial changes when navigating the overlay with arrow keys.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/329)
<!-- Reviewable:end -->
