### PR TITLE
Fix overriding combobox variable in advanced demos

### DIFF
--- a/demo/advanced.html
+++ b/demo/advanced.html
@@ -60,9 +60,9 @@
           <paper-icon-button icon="search" class="toggle-button"></paper-icon-button>
         </vaadin-combo-box>
         <script>
-          var combobox = document.querySelector('#demo2');
+          var combobox2 = document.querySelector('#demo2');
           // Array of String values.
-          combobox.items = elements;
+          combobox2.items = elements;
         </script>
       </template>
     </demo-snippet>
@@ -74,9 +74,9 @@
           <input is="iron-input">
         </vaadin-combo-box-light>
         <script>
-          var combobox = document.querySelector('#demo3');
+          var combobox3 = document.querySelector('#demo3');
           // Array of String values.
-          combobox.items = elements;
+          combobox3.items = elements;
         </script>
       </template>
     </demo-snippet>
@@ -93,9 +93,9 @@
           </paper-input>
         </vaadin-combo-box-light>
         <script>
-          var combobox = document.querySelector('#demo4');
+          var combobox4 = document.querySelector('#demo4');
           // Array of String values.
-          combobox.items = elements;
+          combobox4.items = elements;
         </script>
       </template>
     </demo-snippet>


### PR DESCRIPTION
In advanced usage demos, the first example is broken in `document.querySelector('#selected-value2').innerHTML = combobox.value;` because combobox variable is overwritten with another combo-box in the same file. Fix by renaming the combobox variable names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/333)
<!-- Reviewable:end -->
