### PR TITLE
fixes #287: adds support for falsey primitive values

### DIFF
--- a/docs/vaadin-combo-box-objects.adoc
+++ b/docs/vaadin-combo-box-objects.adoc
@@ -20,6 +20,14 @@ var combobox = document.querySelector('vaadin-combo-box');
 combobox.items = [{ label: 'Display Value', value: 'Actual Value' }];
 ----
 
+The [propertyname]#value# property of the Object can hold String, Number or a Boolean primitive values. All truthy values as well as 0, -0 and false are supported. All other falsey values are not supported (such as NaN, undefined, null, '', etc);
+
+[source,javascript]
+----
+var combobox = document.querySelector('vaadin-combo-box');
+combobox.items = [{ label: 'zero', value: 0 }, { label: 'false', value: false }];
+----
+
 You can override the default property paths by defining [propertyname]#item-label-path# and [propertyname]#item-value-path# properties.
 
 [source,html]

--- a/docs/vaadin-combo-box-objects.adoc
+++ b/docs/vaadin-combo-box-objects.adoc
@@ -20,7 +20,7 @@ var combobox = document.querySelector('vaadin-combo-box');
 combobox.items = [{ label: 'Display Value', value: 'Actual Value' }];
 ----
 
-The [propertyname]#value# property of the Object can hold String, Number or a Boolean primitive values. All truthy values as well as 0, -0 and false are supported. All other falsey values are not supported (such as NaN, undefined, null, '', etc);
+The [propertyname]#value# property of the Object can hold String, Number or a Boolean primitive values. All truthy values as well as 0, -0 and false are supported. All other falsey values are not supported (such as NaN, undefined, null).
 
 [source,javascript]
 ----

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -45,6 +45,14 @@
           label: 'false',
           custom: 'false-custom',
           value: false
+        }, {
+          label: 'empty string',
+          custom: 'empty-string-custom',
+          value: ''
+        }, {
+          label: 'zero as a string',
+          custom: 'zero-string-custom',
+          value: '0'
         }];
       });
 
@@ -142,6 +150,24 @@
 
         expect(combobox.$.input.bindValue).to.eql('false');
         expect(combobox.value).to.eql(false);
+      });
+
+      it('should set the value even if the value is an empty string', function() {
+        combobox.$.overlay.$.selector.selectItem(4);
+
+        expect(combobox.$.input.bindValue).to.eql('empty string');
+        expect(combobox.value).to.eql('');
+        expect(combobox.hasValue).to.eql(true);
+      });
+
+      it('should distinguish between 0 (number) and "0" (string) values', function() {
+        combobox.$.overlay.$.selector.selectItem(2);
+        expect(combobox.$.input.bindValue).to.eql('zero');
+        expect(combobox.value).to.eql(0);
+
+        combobox.$.overlay.$.selector.selectItem(5);
+        expect(combobox.$.input.bindValue).to.eql('zero as a string');
+        expect(combobox.value).to.eql('0');
       });
 
       it('should set the input value from item label if item is found', function() {

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -37,6 +37,14 @@
           label: 'baz',
           custom: 'bashcsdfsa',
           value: 'qux'
+        }, {
+          label: 'zero',
+          custom: 'zero-custom',
+          value: 0
+        }, {
+          label: 'false',
+          custom: 'false-custom',
+          value: false
         }];
       });
 
@@ -120,6 +128,20 @@
 
         expect(combobox.$.input.bindValue).to.eql('foo');
         expect(combobox.value).to.eql('bar');
+      });
+
+      it('should set the value even if the value is zero (number)', function() {
+        combobox.$.overlay.$.selector.selectItem(2);
+
+        expect(combobox.$.input.bindValue).to.eql('zero');
+        expect(combobox.value).to.eql(0);
+      });
+
+      it('should set the value even if the value is false (boolean)', function() {
+        combobox.$.overlay.$.selector.selectItem(3);
+
+        expect(combobox.$.input.bindValue).to.eql('false');
+        expect(combobox.value).to.eql(false);
       });
 
       it('should set the input value from item label if item is found', function() {

--- a/test/vaadin-combo-box-properties.html
+++ b/test/vaadin-combo-box-properties.html
@@ -23,6 +23,8 @@
 
       beforeEach(function() {
         comboBox = fixture('combobox');
+        combobox.items = undefined;
+        combobox.value = undefined;
       });
 
       describe('items property', function() {
@@ -56,6 +58,38 @@
           comboBox.push('items', 'baz');
 
           expect(comboBox._focusedIndex).to.eql(2);
+        });
+      });
+
+      describe('non-string values', function() {
+        it('should allow numeric valules in the items array', function() {
+          comboBox.items = [3, 2, 1, 0];
+          comboBox.value = 0;
+
+          expect(comboBox.$.overlay.$.selector.items).to.eql([3, 2, 1, 0]);
+          expect(comboBox._focusedIndex).to.eql(3);
+          expect(comboBox.$.input.bindValue).to.eql('0');
+          expect(comboBox.value).to.eql(0);
+        });
+
+        it('should allow boolean valules in the items array', function() {
+          comboBox.items = [true, false, true, false];
+          comboBox.value = false;
+
+          expect(comboBox.$.overlay.$.selector.items).to.eql([true, false, true, false]);
+          expect(comboBox._focusedIndex).to.eql(1);
+          expect(comboBox.$.input.bindValue).to.eql('false');
+          expect(comboBox.value).to.eql(false);
+        });
+
+        it('should allow empty string valules in the items array', function() {
+          comboBox.items = ['a', '', 'b'];
+          comboBox.value = '';
+
+          expect(comboBox.$.overlay.$.selector.items).to.eql(['a', '', 'b']);
+          expect(comboBox._focusedIndex).to.eql(1);
+          expect(comboBox.$.input.bindValue).to.eql('');
+          expect(comboBox.value).to.eql('');
         });
       });
 

--- a/test/vaadin-combo-box-properties.html
+++ b/test/vaadin-combo-box-properties.html
@@ -75,7 +75,7 @@
 
         it('should be able to be set before object items', function() {
           var item = {label: 'foo', value: 1};
-          comboBox.value = '1';
+          comboBox.value = 1;
 
           comboBox.items = [item];
 

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -481,7 +481,7 @@
       items = items || this.items;
       if (items && this._isValidValue(value)) {
         for (var i = 0; i < items.length; i++) {
-          if (this._getItemValue(items[i]).toString() === value.toString()) {
+          if (this._getItemValue(items[i]) === value) {
             return i;
           }
         }
@@ -491,16 +491,14 @@
     },
 
     /**
-     * Checks if the value is supported an an item value in this control.
+     * Checks if the value is supported as an item value in this control.
      *
      * @return {boolean}
      */
     _isValidValue: function(value) {
-      // !!value my evaluate to false even for some acceptable values
+      // !!value might evaluate to false even for some acceptable values
       // See the full list here: http://stackoverflow.com/a/19839953
-      var isTruthy = !!value;
-      var isOneOfAcceptedFalseyValues = (value === 0) || (value === -0) || (value === false);
-      return isTruthy || isOneOfAcceptedFalseyValues;
+      return !!value || (value === 0 || value === -0 || value === false || value === "");
     },
 
     _selectedItemChanged: function(event, detail) {

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -498,7 +498,7 @@
     _isValidValue: function(value) {
       // !!value might evaluate to false even for some acceptable values
       // See the full list here: http://stackoverflow.com/a/19839953
-      return !!value || (value === 0 || value === -0 || value === false || value === "");
+      return value !== NaN && value !== undefined && value !== null;
     },
 
     _selectedItemChanged: function(event, detail) {

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -420,7 +420,7 @@
     },
 
     _valueChanged: function(value) {
-      this.hasValue = !!value;
+      this.hasValue = this._isValidValue(value);
 
       var valueIndex = this._indexOfValue(value);
       var item = valueIndex > -1 && this.items[valueIndex];
@@ -479,7 +479,7 @@
 
     _indexOfValue: function(value, items) {
       items = items || this.items;
-      if (items && value) {
+      if (items && this._isValidValue(value)) {
         for (var i = 0; i < items.length; i++) {
           if (this._getItemValue(items[i]).toString() === value.toString()) {
             return i;
@@ -488,6 +488,19 @@
       }
 
       return -1;
+    },
+
+    /**
+     * Checks if the value is supported an an item value in this control.
+     *
+     * @return {boolean}
+     */
+    _isValidValue: function(value) {
+      // !!value my evaluate to false even for some acceptable values
+      // See the full list here: http://stackoverflow.com/a/19839953
+      var isTruthy = !!value;
+      var isOneOfAcceptedFalseyValues = (value === 0) || (value === -0) || (value === false);
+      return isTruthy || isOneOfAcceptedFalseyValues;
     },
 
     _selectedItemChanged: function(event, detail) {


### PR DESCRIPTION
Fixes #287 

When using Objects as Items primitives 0, -0 and false are now acceptable as values for the <vaadin-combo-box>. Example:

```
items = [ { value: 0, label: "zero" }, { value: false, label: "false" } ];
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/340)

<!-- Reviewable:end -->
