### PR TITLE
Update input value async instead of relying on aria-atomic

### DIFF
--- a/test/aria.html
+++ b/test/aria.html
@@ -96,36 +96,6 @@
         expect(getItemElement(0).getAttribute('aria-selected')).to.equal('false');
         expect(getItemElement(1).getAttribute('aria-selected')).to.equal('true');
       });
-
-      it('should change the input value with atomic change', function(done) {
-        comboBox.$.overlay.fire('selection-changed', {item: 'foo'});
-
-        getInput().addEventListener('bind-value-changed', function() {
-          expect(getInput().getAttribute('aria-atomic')).to.equal('true');
-          done();
-        });
-
-        arrowDown();
-        arrowDown();
-      });
-
-      it('should preserve aria-atomic attribute in the input', function() {
-        getInput().setAttribute('aria-atomic', 'false');
-
-        comboBox.value = 'foo';
-        arrowDown();
-        arrowDown();
-
-        expect(getInput().getAttribute('aria-atomic')).to.equal('false');
-      });
-
-      it('should clean-up aria-atomic attribute in the input if was not set', function() {
-        comboBox.value = 'foo';
-        arrowDown();
-        arrowDown();
-
-        expect(getInput().hasAttribute('aria-atomic')).to.be.false;
-      });
     });
 
   });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -231,50 +231,75 @@
         expect(comboBox.value).to.equal('baz');
       });
 
-      it('should prefill the input field when navigating down', function() {
+      it('should reset the input value synchronously when keyboard navigating', function() {
         arrowDown();
 
-        expect(getInput().bindValue).to.eql('baz');
+        expect(getInput().bindValue).to.eql('');
       });
 
-      it('should select the input field text when navigating down', function() {
+      it('should prefill the input field when navigating down', function(done) {
         arrowDown();
 
-        expect(getInput().selectionStart).to.eql(0);
-        expect(getInput().selectionEnd).to.eql(3);
+        comboBox.async(function() {
+          expect(getInput().bindValue).to.eql('baz');
+          done();
+        }, 1);
       });
 
-      it('should prefill the input field when navigating up', function() {
+      it('should select the input field text when navigating down', function(done) {
+        arrowDown();
+
+        comboBox.async(function() {
+          expect(getInput().selectionStart).to.eql(0);
+          expect(getInput().selectionEnd).to.eql(3);
+          done();
+        }, 1);
+      });
+
+      it('should prefill the input field when navigating up', function(done) {
         arrowUp();
 
-        expect(getInput().bindValue).to.eql('foo');
+        comboBox.async(function() {
+          expect(getInput().bindValue).to.eql('foo');
+          done();
+        }, 1);
       });
 
-      it('should not prefill the input when there are no items to navigate', function() {
+      it('should not prefill the input when there are no items to navigate', function(done) {
         filter('invalid filter');
 
         arrowDown();
 
-        expect(getInput().bindValue).to.eql('invalid filter');
+        comboBox.async(function() {
+          expect(getInput().bindValue).to.eql('invalid filter');
+          done();
+        }, 1);
       });
 
-      it('should select the input field text when navigating up', function() {
+      it('should select the input field text when navigating up', function(done) {
         arrowUp();
 
-        expect(getInput().selectionStart).to.eql(0);
-        expect(getInput().selectionEnd).to.eql(3);
+        comboBox.async(function() {
+          expect(getInput().selectionStart).to.eql(0);
+          expect(getInput().selectionEnd).to.eql(3);
+          done();
+        }, 1);
       });
 
-      it('should revert back to filter with espace', function() {
+      it('should revert back to filter with espace', function(done) {
         filter('b');
 
         arrowDown();
 
-        expect(getInput().bindValue).to.eql('bar');
+        comboBox.async(function() {
+          expect(getInput().bindValue).to.eql('bar');
 
-        esc();
+          esc();
 
-        expect(getInput().bindValue).to.eql('b');
+          expect(getInput().bindValue).to.eql('b');
+          done();
+        }, 1);
+
       });
 
       it('should remove selection from the input value when reverting', function() {

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -263,19 +263,13 @@
 
     _prefillFocusedItemLabel: function() {
       if (this._focusedIndex > -1) {
-        // Temporarily set aria-atomic="true" to prevent partial value changes
+        // Reset the input value asyncronously to prevent partial value changes
         // announce. Makes OSX VoiceOver to announce the complete value instead.
-        var oldAriaAtomic = this.inputElement.getAttribute('aria-atomic');
-        this.inputElement.setAttribute('aria-atomic', true);
-
-        this._inputElementValue =  this._getItemLabel(this.$.overlay._focusedItem);
-        this._setSelectionRange();
-
-        if (oldAriaAtomic !== null) {
-          this.inputElement.setAttribute('aria-atomic', oldAriaAtomic);
-        } else {
-          this.inputElement.removeAttribute('aria-atomic');
-        }
+        this._inputElementValue = '';
+        this.async(function() {
+          this._inputElementValue =  this._getItemLabel(this.$.overlay._focusedItem);
+          this._setSelectionRange();
+        }, 1); // 1ms delay needed for OSX VoiceOver to realise input value was reset
       }
     },
 


### PR DESCRIPTION
Fixes VoiceOver reading out focused items when navigating with keyboard.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/358)
<!-- Reviewable:end -->
