### PR TITLE
Use suffix slot for clear and toggle icons

### DIFF
--- a/vaadin-combo-box-shared-styles.html
+++ b/vaadin-combo-box-shared-styles.html
@@ -20,7 +20,7 @@
 
       paper-icon-button.small,
       :host ::content paper-icon-button.small {
-        padding: 6px 6px !important;
+        padding: 6px !important;
       }
 
       :host(:not([has-value])) ::content [slot=clear-button],

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -98,10 +98,6 @@ Custom property | Description | Default
       paper-icon-button.toggle-button,
       :host ::content paper-icon-button.clear-button,
       :host ::content paper-icon-button.toggle-button {
-        position: absolute;
-        bottom: -4px;
-        right: -4px;
-
         line-height: 18px !important;
         width: 32px;
         height: 32px;
@@ -112,11 +108,6 @@ Custom property | Description | Default
         cursor: pointer;
         margin-top: -1px;
         --paper-icon-button-ink-color: rgba(0, 0, 0, .54);
-      }
-
-      paper-input-container paper-icon-button.clear-button,
-      paper-input-container ::content paper-icon-button.clear-button {
-        right: 28px;
       }
 
       paper-input-container paper-icon-button:hover,
@@ -139,17 +130,6 @@ Custom property | Description | Default
       #input::-ms-clear {
         display: none;
       }
-
-      #input {
-        box-sizing: border-box;
-        padding-right: 28px;
-      }
-
-      :host([has-value]) #input {
-        padding-right: 60px;
-        margin-right: -32px;
-      }
-
     </style>
 
     <paper-input-container
@@ -196,26 +176,31 @@ Custom property | Description | Default
 
       <slot name="suffix"></slot>
 
-      <slot name="clear-button">
-        <paper-icon-button
-            id="clearIcon"
-            tabindex="-1"
-            aria-label="Clear"
-            icon="vaadin-combo-box:clear"
-            class="clear-button small">
-        </paper-icon-button>
-      </slot>
+      <!-- TODO (web-padawan): remove "suffix" attributes for 2.0 -->
+      <div slot="suffix" suffix>
+        <slot name="clear-button">
+          <paper-icon-button
+              id="clearIcon"
+              tabindex="-1"
+              aria-label="Clear"
+              icon="vaadin-combo-box:clear"
+              class="clear-button small">
+          </paper-icon-button>
+        </slot>
+      </div>
 
-      <slot name="toggle-button">
-        <paper-icon-button
-            id="toggleIcon"
-            tabindex="-1"
-            icon="vaadin-combo-box:arrow-drop-down"
-            aria-label="Toggle"
-            aria-expanded$="[[_getAriaExpanded(opened)]]"
-            class="toggle-button rotate-on-open">
-        </paper-icon-button>
-      </slot>
+      <div slot="suffix" suffix>
+        <slot name="toggle-button">
+          <paper-icon-button
+              id="toggleIcon"
+              tabindex="-1"
+              icon="vaadin-combo-box:arrow-drop-down"
+              aria-label="Toggle"
+              aria-expanded$="[[_getAriaExpanded(opened)]]"
+              class="toggle-button rotate-on-open">
+          </paper-icon-button>
+        </slot>
+      </div>
 
       <template is="dom-if" if="[[errorMessage]]">
         <paper-input-error>[[errorMessage]]</paper-input-error>


### PR DESCRIPTION
Just as @jouni has mentioned [here](https://github.com/vaadin/vaadin-combo-box/issues/424#issuecomment-288422095).

Please check if I removed correct styles, especially those related to clear icon (there used to be some different padding and negative `bottom`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/425)
<!-- Reviewable:end -->
