### PR TITLE
Fix overlay scrolling via the scrollbar in IE

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -179,7 +179,7 @@
     },
 
     _onBlur: function() {
-      if (!this._closeOnBlurIsPrevented && document.activeElement !== this.$.overlay.$.scroller) {
+      if (!this._closeOnBlurIsPrevented && document.activeElement !== this.$.overlay.$.scroller && document.activeElement !== null) {
         this.close();
       }
     },

--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -179,7 +179,7 @@
     },
 
     _onBlur: function() {
-      if (!this._closeOnBlurIsPrevented) {
+      if (!this._closeOnBlurIsPrevented && document.activeElement !== this.$.overlay.$.scroller) {
         this.close();
       }
     },


### PR DESCRIPTION
In IE clicking on the scrollbar causes the internal input element to loose the focus and close the overlay.
This is unintended, and with this additional check it can be avoided.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/437)
<!-- Reviewable:end -->
