### PR TITLE
Change CSS-positioning of overlay

### DIFF
--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -133,7 +133,8 @@
       var _devicePixelRatio = window.devicePixelRatio || 1;
       this._translateX = Math.round(this._translateX * _devicePixelRatio) / _devicePixelRatio;
       this._translateY = Math.round(this._translateY * _devicePixelRatio) / _devicePixelRatio;
-      this.translate3d(this._translateX + 'px', this._translateY + 'px', '0');
+      this.style.top = this._translateY + 'px';
+      this.style.left = this._translateX + 'px';
 
       this.style.width = this.positionTarget.clientWidth + 'px';
 


### PR DESCRIPTION
As in #344  mentioned when opening the vaadin-combo-box-overlay in IE 11 the translate3d isn't working as expected. The items are not selectable.
When using the top and left-values it is working as expected.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/441)
<!-- Reviewable:end -->
