### PR TITLE
Add support for tabindex

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -396,19 +396,19 @@ Custom property | Description | Default
     _onInputContainerFocusedChanged: function(e) {
       this._setFocused(e.detail.value);
     },
-	
-	/**
-	 * Forward focus to inputElement. Overriden from IronControlState.
-	 */
-	_focusBlurHandler: function (event) {
-	  Polymer.IronControlState._focusBlurHandler.call(this, event);
-	  // Forward the focus to the nested input.
-	  if (!this.focused)
-		  this.async(this.close, 100);
-	  ;
-	  if (this.focused && !this._shiftTabPressed)
-		  this.$.input.focus();
-	}	
+    
+    /**
+     * Forward focus to inputElement. Overriden from IronControlState.
+     */
+    _focusBlurHandler: function (event) {
+      Polymer.IronControlState._focusBlurHandler.call(this, event);
+      // Forward the focus to the nested input.
+      if (!this.focused)
+          this.async(this.close, 100);
+      ;
+      if (this.focused && !this._shiftTabPressed)
+          this.$.input.focus();
+    }
   });
 
 </script>

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -228,7 +228,7 @@ Custom property | Description | Default
     behaviors: [
       Polymer.IronValidatableBehavior,
       vaadin.elements.combobox.ComboBoxBehavior,
-	  Polymer.IronControlState
+      Polymer.IronControlState
     ],
 
     properties: {
@@ -400,14 +400,13 @@ Custom property | Description | Default
     /**
      * Forward focus to inputElement. Overriden from IronControlState.
      */
-    _focusBlurHandler: function (event) {
+    _focusBlurHandler: function(event) {
       Polymer.IronControlState._focusBlurHandler.call(this, event);
       // Forward the focus to the nested input.
       if (!this.focused)
-          this.async(this.close, 100);
-      ;
+        this.async(this.close, 100);
       if (this.focused && !this._shiftTabPressed)
-          this.$.input.focus();
+        this.$.input.focus();
     }
   });
 

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -227,7 +227,8 @@ Custom property | Description | Default
 
     behaviors: [
       Polymer.IronValidatableBehavior,
-      vaadin.elements.combobox.ComboBoxBehavior
+      vaadin.elements.combobox.ComboBoxBehavior,
+	  Polymer.IronControlState
     ],
 
     properties: {
@@ -394,7 +395,20 @@ Custom property | Description | Default
 
     _onInputContainerFocusedChanged: function(e) {
       this._setFocused(e.detail.value);
-    }
+    },
+	
+	/**
+	 * Forward focus to inputElement. Overriden from IronControlState.
+	 */
+	_focusBlurHandler: function (event) {
+	  Polymer.IronControlState._focusBlurHandler.call(this, event);
+	  // Forward the focus to the nested input.
+	  if (!this.focused)
+		  this.async(this.close, 100);
+	  ;
+	  if (this.focused && !this._shiftTabPressed)
+		  this.$.input.focus();
+	}	
   });
 
 </script>


### PR DESCRIPTION
I solved the tabindex support by adding the same solution as it exist for [paper-input-behavior](https://github.com/PolymerElements/paper-input/blob/master/paper-input-behavior.html).
Fixes #401

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/466)
<!-- Reviewable:end -->
