### PR TITLE
Prevent events closing the dropdown being propagated up

### DIFF
--- a/test/form-input.html
+++ b/test/form-input.html
@@ -38,7 +38,7 @@
         comboBox.allowCustomValue = true;
 
         // make iron-input pick up child input
-        if(comboBox._bindableInput._initSlottedInput) {
+        if (comboBox._bindableInput._initSlottedInput) {
           comboBox._bindableInput._initSlottedInput();
         }
       });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -259,7 +259,7 @@
           if (e.keyCode == 27) {
             throw new Error('Escape key was propagated to body');
           }
-        })
+        });
 
         esc();
 
@@ -269,7 +269,7 @@
       it('click event should not be propagated', () => {
         const listener = document.body.addEventListener('click', () => {
           throw new Error('Click event was propagated to body');
-        })
+        });
 
         comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item')
           .dispatchEvent(new CustomEvent('click', {composed: true, bubbles: true}));
@@ -280,7 +280,7 @@
       it('tap event should not be propagated', () => {
         const listener = document.body.addEventListener('tap', () => {
           throw new Error('Tap event was propagated to body');
-        })
+        });
 
         comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item')
           .dispatchEvent(new CustomEvent('tap', {composed: true, bubbles: true}));

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -254,6 +254,40 @@
         expect(comboBox.opened).to.equal(false);
       });
 
+      it('escape key event should not be propagated', () => {
+        const listener = document.body.addEventListener('keydown', e => {
+          if (e.keyCode == 27) {
+            throw new Error('Escape key was propagated to body');
+          }
+        })
+
+        esc();
+
+        document.body.removeEventListener('keydown', listener);
+      });
+
+      it('click event should not be propagated', () => {
+        const listener = document.body.addEventListener('click', () => {
+          throw new Error('Click event was propagated to body');
+        })
+
+        comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item')
+          .dispatchEvent(new CustomEvent('click', {composed: true, bubbles: true}));
+
+        document.body.removeEventListener('click', listener);
+      });
+
+      it('tap event should not be propagated', () => {
+        const listener = document.body.addEventListener('tap', () => {
+          throw new Error('Tap event was propagated to body');
+        })
+
+        comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item')
+          .dispatchEvent(new CustomEvent('tap', {composed: true, bubbles: true}));
+
+        document.body.removeEventListener('tap', listener);
+      });
+
       it('should cancel typing with escape', () => {
         filter('baz');
 

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -101,7 +101,9 @@
     it('should not fire `selection-changed` after scrolling for grace period of 300ms', done => {
       // We need more items to increase scroller
       const items = [];
-      for (let i = 1; i < 50; i++) items.push(i);
+      for (let i = 1; i < 50; i++) {
+        items.push(i);
+      }
       combobox.items = items;
 
       // open the combo box, and move the scroll
@@ -129,7 +131,9 @@
 
     it('should fire `selection-changed` after the scrolling grace period', done => {
       const items = [];
-      for (let i = 1; i < 50; i++) items.push(i);
+      for (let i = 1; i < 50; i++) {
+        items.push(i);
+      }
       combobox.items = items;
 
       combobox.opened = true;

--- a/vaadin-combo-box-mixin.html
+++ b/vaadin-combo-box-mixin.html
@@ -260,7 +260,7 @@ This program is available under Apache License Version 2.0, available at https:/
       } else if (this._isEventKey(e, 'enter')) {
         this._onEnter(e);
       } else if (this._isEventKey(e, 'esc')) {
-        this._onEscape();
+        this._onEscape(e);
       }
     }
 
@@ -362,8 +362,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _onEscape() {
+    _onEscape(e) {
       if (this.opened) {
+        this._stopPropagation(e);
+
         if (this._focusedIndex > -1) {
           this._focusedIndex = -1;
           this._revertInputValue();

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -332,7 +332,9 @@ This program is available under Apache License Version 2.0, available at https:/
         // Sometimes the item is partly below the bottom edge, detect and adjust.
         const pidx = this._selector._getPhysicalIndex(index),
           physicalItem = this._selector._physicalItems[pidx];
-        if (!physicalItem) return;
+        if (!physicalItem) {
+          return;
+        }
         const physicalItemRect = physicalItem.getBoundingClientRect(),
           scrollerRect = this._scroller.getBoundingClientRect(),
           scrollTopAdjust = physicalItemRect.bottom - scrollerRect.bottom + this._viewportTotalPaddingBottom;

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -244,6 +244,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _onTap(e) {
         if (!this._notTapping && !this._ignoreTaps) {
+          if (e.detail && e.detail.sourceEvent && e.detail.sourceEvent.stopPropagation) {
+            this._stopPropagation(e.detail.sourceEvent);
+          }
+
           this.dispatchEvent(new CustomEvent('selection-changed', {detail: {item: e.model.item}}));
         }
       }


### PR DESCRIPTION
When having combo-box in BAS dialogs, when selecting an item or closing the overlay with escape, closes the dialog. 
This happens because the overlay is attached directly to body, so the check in BAS dialogs to avoid clicks coming for elements inside it fails, because composed path does not include the dialog.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/478)
<!-- Reviewable:end -->
