### PR TITLE
replace `vaadin.` with `window.vaadin.`

### DIFF
--- a/vaadin-combo-box-behavior.html
+++ b/vaadin-combo-box-behavior.html
@@ -4,11 +4,11 @@
 
 <script>
   window.vaadin = window.vaadin || {};
-  vaadin.elements = vaadin.elements || {};
-  vaadin.elements.combobox = vaadin.elements.combobox || {};
+  window.vaadin.elements = window.vaadin.elements || {};
+  window.vaadin.elements.combobox = window.vaadin.elements.combobox || {};
 
-  /** @polymerBehavior vaadin.elements.combobox.ComboBoxBehavior */
-  vaadin.elements.combobox.ComboBoxBehaviorImpl = {
+  /** @polymerBehavior window.vaadin.elements.combobox.ComboBoxBehavior */
+  window.vaadin.elements.combobox.ComboBoxBehaviorImpl = {
     properties: {
       /**
        * A full set of items to filter the visible options from.
@@ -703,12 +703,12 @@
     }
   };
 
-  /** @polymerBehavior vaadin.elements.combobox.ComboBoxBehavior */
-  vaadin.elements.combobox.ComboBoxBehavior = [
+  /** @polymerBehavior window.vaadin.elements.combobox.ComboBoxBehavior */
+  window.vaadin.elements.combobox.ComboBoxBehavior = [
     Polymer.IronFormElementBehavior,
     Polymer.Templatizer,
-    vaadin.elements.combobox.DropdownBehavior,
-    vaadin.elements.combobox.ComboBoxBehaviorImpl
+    window.vaadin.elements.combobox.DropdownBehavior,
+    window.vaadin.elements.combobox.ComboBoxBehaviorImpl
   ];
 
   /**

--- a/vaadin-combo-box-light.html
+++ b/vaadin-combo-box-light.html
@@ -77,7 +77,7 @@ two `<paper-button>`s to act as the clear and toggle controls.
 
     behaviors: [
       Polymer.IronA11yKeysBehavior,
-      vaadin.elements.combobox.ComboBoxBehavior
+      window.vaadin.elements.combobox.ComboBoxBehavior
     ],
 
     properties: {

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -107,7 +107,7 @@
     is: 'vaadin-combo-box-overlay',
 
     behaviors: [
-      vaadin.elements.combobox.OverlayBehavior
+      window.vaadin.elements.combobox.OverlayBehavior
     ],
 
     properties: {

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -239,7 +239,7 @@ Custom property | Description | Default
 
     behaviors: [
       Polymer.IronValidatableBehavior,
-      vaadin.elements.combobox.ComboBoxBehavior
+      window.vaadin.elements.combobox.ComboBoxBehavior
     ],
 
     properties: {

--- a/vaadin-dropdown-behavior.html
+++ b/vaadin-dropdown-behavior.html
@@ -1,10 +1,10 @@
 <script>
   window.vaadin = window.vaadin || {};
-  vaadin.elements = vaadin.elements || {};
-  vaadin.elements.combobox = vaadin.elements.combobox || {};
+  window.vaadin.elements = window.vaadin.elements || {};
+  window.vaadin.elements.combobox = window.vaadin.elements.combobox || {};
 
-  /** @polymerBehavior vaadin.elements.combobox.DropdownBehavior */
-  vaadin.elements.combobox.DropdownBehavior = {
+  /** @polymerBehavior window.vaadin.elements.combobox.DropdownBehavior */
+  window.vaadin.elements.combobox.DropdownBehavior = {
     properties: {
       /**
        * True if the dropdown is open, false otherwise.

--- a/vaadin-overlay-behavior.html
+++ b/vaadin-overlay-behavior.html
@@ -2,11 +2,11 @@
 
 <script>
   window.vaadin = window.vaadin || {};
-  vaadin.elements = vaadin.elements || {};
-  vaadin.elements.combobox = vaadin.elements.combobox || {};
+  window.vaadin.elements = window.vaadin.elements || {};
+  window.vaadin.elements.combobox = window.vaadin.elements.combobox || {};
 
-  /** @polymerBehavior vaadin.elements.combobox.OverlayBehavior */
-  vaadin.elements.combobox.OverlayBehaviorImpl = {
+  /** @polymerBehavior window.vaadin.elements.combobox.OverlayBehavior */
+  window.vaadin.elements.combobox.OverlayBehaviorImpl = {
     properties: {
       /**
        * The element to position/align the dropdown by.
@@ -152,8 +152,8 @@
   };
 
   /** @polymerBehavior */
-  vaadin.elements.combobox.OverlayBehavior = [
+  window.vaadin.elements.combobox.OverlayBehavior = [
     Polymer.IronResizableBehavior,
-    vaadin.elements.combobox.OverlayBehaviorImpl
+    window.vaadin.elements.combobox.OverlayBehaviorImpl
   ];
 </script>


### PR DESCRIPTION
Using both `window.vaadin` and `vaadin` to refer to the same namespace breaks compiling in closure. This has been encountered and worked around/fixed in `vaadin-grid` by using a consistent name (`window.vaadin`) in https://github.com/vaadin/vaadin-grid/pull/872/

This patch applies the analogous change to `vaadin-combo-box`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/482)
<!-- Reviewable:end -->
