### PR TITLE
Disabling shadydom tests in chrome

### DIFF
--- a/test/index.html
+++ b/test/index.html
@@ -38,14 +38,7 @@
       'item-template.html',
       'vaadin-overlay.html',
       'vaadin-dropdown.html'
-    ].reduce((suites, suite) => {
-      // Browser supports Shadow DOM
-      if (document.head.createShadowRoot || document.head.attachShadow) {
-        return suites.concat([suite, suite + '?wc-shadydom=true&dom=shadow']);
-      } else {
-        return suites.concat([suite]);
-      }
-    }, []));
+    ]);
   </script>
 </body>
 


### PR DESCRIPTION
Builds started to fail due to some changes in polymer or polyfill that makes test fail when run in chrome shadydom. Otherwise tests pass in browsers that does not support shadow dom.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/487)
<!-- Reviewable:end -->
