### PR TITLE
Use control-state-mixin's feature to prevent focus

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,8 +9,6 @@
     "html"
   ],
   "globals": {
-    // TODO: remove when moving to ES6 vaadin -> Vaadin
-    "vaadin": false,
     "Vaadin": false,
     "Polymer": false,
     "CustomElements": false

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -19,6 +19,7 @@
     "it": false,
     "fixture": false,
     "fire": false,
+    "fireMousedownMouseupClick": false,
     "System": false,
     "HTMLImports": false,
     "MockInteractions": false,

--- a/test/common.js
+++ b/test/common.js
@@ -19,6 +19,12 @@ const fire = (type, node, detail) => {
   return evt;
 };
 
+const fireMousedownMouseupClick = (node) => {
+  fire('mousedown', node);
+  fire('mouseup', node);
+  fire('click', node);
+};
+
 const describeSkipIf = (bool, title, callback) => {
   bool = typeof bool == 'function' ? bool() : bool;
   if (bool) {

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -33,16 +33,8 @@
     let combobox;
     let comboboxLight;
 
-    function clickLabel() {
-      fire('click', combobox.inputElement.root.querySelector('label'));
-    }
-
-    function clickInput() {
-      fire('click', combobox.inputElement);
-    }
-
     function clickToggleIcon() {
-      fire('click', combobox._toggleElement);
+      fireMousedownMouseupClick(combobox._toggleElement);
     }
 
     function overlay() {
@@ -57,7 +49,7 @@
     describe('opening', () => {
       it('should open asynchronously by tapping label', done => {
         expect(combobox.opened).to.be.false;
-        clickLabel();
+        fireMousedownMouseupClick(combobox.inputElement.root.querySelector('label'));
         expect(combobox.opened).to.be.false;
 
         setTimeout(() => {
@@ -68,7 +60,7 @@
 
       it('should open asynchronously by clicking input', done => {
         expect(combobox.opened).to.be.false;
-        clickInput();
+        fireMousedownMouseupClick(combobox.inputElement);
         expect(combobox.opened).to.be.false;
 
         setTimeout(() => {

--- a/vaadin-combo-box-mixin.html
+++ b/vaadin-combo-box-mixin.html
@@ -392,10 +392,15 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _toggleElementChanged(toggleElement) {
-      toggleElement && toggleElement.addEventListener('click', (e) => {
-        this._toggle();
-        e.stopPropagation();
-      });
+      if (toggleElement) {
+        toggleElement.addEventListener('mousedown', (e) => {
+          e.preventDefault();
+        });
+
+        toggleElement.addEventListener('click', (e) => {
+          this._toggle();
+        });
+      }
     }
 
     /**


### PR DESCRIPTION
After merging https://github.com/vaadin/vaadin-control-state-mixin/pull/17 we can prevent focus without stopping `click` propagation.

thx to @platosha :beers:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/509)
<!-- Reviewable:end -->
