### PR TITLE
Add `vaadin-overlay-touch-start` event

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,7 +23,7 @@
     "iron-list": "^2.0.2",
     "iron-resizable-behavior": "^2.0.0",
     "polymer": "^2.0.0",
-    "vaadin-overlay": "^1.1.0",
+    "vaadin-overlay": "^1.2.2",
     "vaadin-text-field": "^1.0.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.1.0"
   },

--- a/vaadin-combo-box-light.html
+++ b/vaadin-combo-box-light.html
@@ -22,7 +22,6 @@ This program is available under Apache License Version 2.0, available at https:/
         _focused-index="[[_focusedIndex]]"
         _item-label-path="[[itemLabelPath]]"
         loading="[[loading]]"
-        on-click="_onOverlayClick"
         vertical-offset="[[overlayVerticalOffset]]">
     </vaadin-combo-box-overlay>
   </template>

--- a/vaadin-combo-box-mixin.html
+++ b/vaadin-combo-box-mixin.html
@@ -199,6 +199,8 @@ This program is available under Apache License Version 2.0, available at https:/
       this.addEventListener('vaadin-combo-box-dropdown-opened', this._onOpened.bind(this));
       this.addEventListener('keydown', this._onKeyDown.bind(this));
       this.addEventListener('click', this._onClick.bind(this));
+
+      this.$.overlay.addEventListener('vaadin-overlay-touch-start', this._onOverlayTouchStart.bind(this));
     }
 
     _onBlur() {
@@ -207,14 +209,12 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
-    _onOverlayClick(event) {
-      if (this.$.overlay.touchDevice && event.target !== this.$.overlay._scroller) {
-        // On touch devices, blur the input on touch start inside the overlay, in order to hide
-        // the virtual keyboard. But don't close the overlay on this blur.
-        this._closeOnBlurIsPrevented = true;
-        this.inputElement.blur();
-        this._closeOnBlurIsPrevented = false;
-      }
+    _onOverlayTouchStart(event) {
+      // On touch devices, blur the input on touch start inside the overlay, in order to hide
+      // the virtual keyboard. But don't close the overlay on this blur.
+      this._closeOnBlurIsPrevented = true;
+      this.inputElement.blur();
+      this._closeOnBlurIsPrevented = false;
     }
 
     _onClick(e) {

--- a/vaadin-combo-box-overlay.html
+++ b/vaadin-combo-box-overlay.html
@@ -156,6 +156,11 @@ This program is available under Apache License Version 2.0, available at https:/
           this._scroller.setAttribute('unselectable', 'on');
         }
 
+        this.$.dropdown.$.overlay.addEventListener('touchstart', sourceEvent => {
+          const evt = new CustomEvent('vaadin-overlay-touch-start', {detail: {sourceEvent: sourceEvent}});
+          this.dispatchEvent(evt);
+        });
+
         // Prevent blurring the input when clicking inside the overlay.
         this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault());
       }

--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -87,7 +87,6 @@ This program is available under Apache License Version 2.0, available at https:/
       position-target="[[_getPositionTarget()]]"
       _focused-index="[[_focusedIndex]]"
       _item-label-path="[[itemLabelPath]]"
-      on-click="_onOverlayClick"
       loading="[[loading]]">
     </vaadin-combo-box-overlay>
   </template>


### PR DESCRIPTION
Fixes #504 

Add `vaadin-overlay-touch-start` event, add listener for it in combo-box-mixin for blurring the input on scrolling of the overlay. `vaadin-overlay` bumped to 1.2.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/516)
<!-- Reviewable:end -->
