### PR TITLE
Use flexbox alignment on <vaadin-overlay>, remove overlay shadow theme override

### DIFF
--- a/vaadin-combo-box-dropdown.html
+++ b/vaadin-combo-box-dropdown.html
@@ -20,7 +20,7 @@ This program is available under Apache License Version 2.0, available at https:/
         display: none;
       }
     </style>
-    <vaadin-overlay id="overlay" opened="[[opened]]" template="{{template}}">
+    <vaadin-overlay id="overlay" opened="[[opened]]" template="{{template}}" style="align-items: stretch;">
       <slot></slot>
     </vaadin-overlay>
   </template>
@@ -246,6 +246,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.overlay.style.transform = `translate3d(${this._translateX}px, ${this._translateY}px, 0)`;
 
         this.$.overlay.style.width = this.positionTarget.clientWidth + 'px';
+        this.$.overlay.style.justifyContent = this.alignedAbove ? 'flex-end' : 'flex-start';
 
         // TODO: fire only when position actually changes changes
         this.dispatchEvent(new CustomEvent('position-changed'));

--- a/vaadin-combo-box-styles.html
+++ b/vaadin-combo-box-styles.html
@@ -33,16 +33,6 @@ This program is available under Apache License Version 2.0, available at https:/
   </template>
 </dom-module>
 
-<dom-module id="vaadin-combo-box-vaadin-overlay-theme" theme-for="vaadin-overlay">
-  <template>
-    <style include="vaadin-overlay-default-theme">
-      :host {
-        box-shadow: 0 2px 8px 0 rgba(0, 0, 0, 0.3);
-      }
-    </style>
-  </template>
-</dom-module>
-
 <dom-module id="vaadin-combo-box-item-default-theme" theme-for="vaadin-combo-box-item">
   <template>
     <style>


### PR DESCRIPTION
Connected to vaadin/vaadin-overlay#22
Depends on vaadin/vaadin-overlay#25

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/524)
<!-- Reviewable:end -->
