### PR TITLE
Remove unnecessary default theme styles

### DIFF
--- a/vaadin-combo-box-styles.html
+++ b/vaadin-combo-box-styles.html
@@ -18,16 +18,9 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-combo-box-default-theme" theme-for="vaadin-combo-box vaadin-combo-box-light" >
   <template>
     <style>
-      :host {
-        padding: 8px 0;
-      }
-
       [part="clear-button"],
       [part="toggle-button"] {
         cursor: pointer;
-        display: flex;
-        justify-content: center;
-        align-items: center;
       }
     </style>
   </template>


### PR DESCRIPTION
The padding is now aligned with the default text-field and date-picker
themes (no padding). Fixes #525

Remove the flex container styles from the buttons, they did not alter
the visual display in any way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/533)
<!-- Reviewable:end -->
