### PR TITLE
Add vaadin-control-state-mixin Bower dependency

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -23,6 +23,7 @@
     "iron-list": "^2.0.2",
     "iron-resizable-behavior": "^2.0.0",
     "polymer": "^2.0.0",
+    "vaadin-control-state-mixin": "^1.1.4",
     "vaadin-overlay": "^1.2.2",
     "vaadin-text-field": "^1.0.0",
     "vaadin-themable-mixin": "^1.1.0"


### PR DESCRIPTION
Since we're using `vaadin-control-state-mixin` [in vaadin-combo-box](https://github.com/vaadin/vaadin-combo-box/blob/master/vaadin-combo-box.html#L160) we should explicitly depend on it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/535)
<!-- Reviewable:end -->
