### PR TITLE
Propagate readonly attribute to the internal vaadin-text-field

### DIFF
--- a/vaadin-combo-box.html
+++ b/vaadin-combo-box.html
@@ -65,7 +65,7 @@ This program is available under Apache License Version 2.0, available at https:/
         placeholder="[[placeholder]]"
         required="[[required]]"
         disabled="[[disabled]]"
-        readonly="[[readonly]]"
+        readonly$="[[readonly]]"
         error-message="[[errorMessage]]"
 
         autocapitalize="none"


### PR DESCRIPTION
Fixes #548 

Propagate `readonly` attribute to the internal `vaadin-text-field`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/560)
<!-- Reviewable:end -->
