### PR TITLE
Correct line endings of some files types

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# The default behavior
+* text=auto
+
+*.json text
+
+.gitattributes text
+.gitignore text


### PR DESCRIPTION
Symptom: in windows with current `master`, running `npm install` will make `package.json` marked as changed, because it make the line ending *nix `LineFeed`

Other types could be added to, e.g. `.html`, `.js`, etc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/578)
<!-- Reviewable:end -->
