### PR TITLE
Update theme and demos

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     "vaadin-overlay": "^2.0.0",
     "vaadin-text-field": "^2.0.0",
     "vaadin-themable-mixin": "^1.1.0",
-    "vaadin-valo-theme": "^2.0.0",
+    "vaadin-valo-styles": "vaadin/vaadin-valo-styles#^2.0.0",
     "vaadin-item": "^2.0.0",
     "vaadin-element-mixin": "vaadin/vaadin-element-mixin#^1.0.1"
   },

--- a/demo/combo-box-advanced-demos.html
+++ b/demo/combo-box-advanced-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="combo-box-advanced-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -8,40 +8,8 @@
     </style>
 
 
-    <h3>Typing Custom Values</h3>
-
-    <vaadin-demo-snippet id='combo-box-advanced-demos-typing-custom-values'>
-      <template preserve-content>
-        <vaadin-combo-box id="demo1" label="Element" allow-custom-value></vaadin-combo-box>
-        <p>Selected value: <span id="selected-value2"></span></p>
-
-        <script>
-          window.addDemoReadyListener('#combo-box-advanced-demos-typing-custom-values', function(document) {
-            var combobox = document.querySelector('#demo1');
-            combobox.items = elements;
-
-            combobox.addEventListener('value-changed', function() {
-              document.querySelector('#selected-value2').innerHTML = combobox.value;
-            });
-
-            combobox.addEventListener('custom-value-set', function(e) {
-              // Prevents setting the value property automatically.
-              e.preventDefault();
-
-              combobox.value = e.detail;
-              document.querySelector('#selected-value2').innerHTML = 'custom value "' + e.detail + '" set!';
-            });
-
-            combobox.value = 'Carbon';
-          });
-        </script>
-
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Configuring Icons</h3>
-    <vaadin-demo-snippet id='combo-box-advanced-demos-configuring-icons'>
+    <vaadin-demo-snippet id="combo-box-advanced-demos-configuring-icons">
       <template preserve-content>
         <style>
           paper-icon-button {
@@ -69,7 +37,7 @@
 
 
     <h3>Replacing the Input with an &lt;iron-input></h3>
-    <vaadin-demo-snippet id='combo-box-advanced-demos-replacing-the-input-with-an-iron-input'>
+    <vaadin-demo-snippet id="combo-box-advanced-demos-replacing-the-input-with-an-iron-input">
       <template preserve-content>
         <vaadin-combo-box-light id="demo3" attr-for-value="bind-value">
           <iron-input>
@@ -88,7 +56,7 @@
 
 
     <h3>Replacing the Input with a &lt;paper-input></h3>
-    <vaadin-demo-snippet id='combo-box-advanced-demos-replacing-the-input-with-a-paper-input'>
+    <vaadin-demo-snippet id="combo-box-advanced-demos-replacing-the-input-with-a-paper-input">
       <template preserve-content>
         <vaadin-combo-box-light id="demo4">
           <paper-input label="Elements" class="input">

--- a/demo/combo-box-basic-demos.html
+++ b/demo/combo-box-basic-demos.html
@@ -109,13 +109,13 @@
 
     <h3>Allow Custom Values</h3>
     <p>Allow the user to set any value for the field in addition to selecting a value from the dropdown menu.</p>
-    <vaadin-demo-snippet id="combo-box-advanced-demos-typing-custom-values">
+    <vaadin-demo-snippet id="combo-box-basic-demos-allow-custom-values">
       <template preserve-content>
         <vaadin-combo-box id="demo1" label="Element" allow-custom-value></vaadin-combo-box>
         <p>Selected value: <span id="selected-value2"></span></p>
 
         <script>
-          window.addDemoReadyListener('#combo-box-advanced-demos-typing-custom-values', function(document) {
+          window.addDemoReadyListener('#combo-box-basic-demos-allow-custom-values', function(document) {
             var combobox = document.querySelector('#demo1');
             combobox.items = elements;
 

--- a/demo/combo-box-basic-demos.html
+++ b/demo/combo-box-basic-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="combo-box-basic-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -10,7 +10,7 @@
 
     <h3>Configuring the Combo Box</h3>
 
-    <vaadin-demo-snippet id='combo-box-basic-demos-configuring-the-combo-box'>
+    <vaadin-demo-snippet id="combo-box-basic-demos-configuring-the-combo-box">
       <template preserve-content>
         <vaadin-combo-box id="demo1-1" label="Element"></vaadin-combo-box>
         <vaadin-combo-box id="demo1-2" label="Disabled" disabled></vaadin-combo-box>
@@ -21,26 +21,15 @@
             var combobox2 = document.querySelector('#demo1-2');
             var combobox3 = document.querySelector('#demo1-3');
             combobox1.items = combobox2.items = combobox3.items = elements;
+            combobox1.value = combobox2.value = combobox3.value = 'Carbon';
           });
         </script>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>TabIndex</h3>
-
-    <vaadin-demo-snippet id='combo-box-basic-demos-tabindex'>
-      <template preserve-content>
-        <vaadin-combo-box tabindex="4" placeholder="TabIndex 4"></vaadin-combo-box>
-        <vaadin-combo-box tabindex="3" placeholder="TabIndex 3"></vaadin-combo-box>
-        <vaadin-combo-box tabindex="2" placeholder="TabIndex 2 disabled" disabled></vaadin-combo-box>
-        <vaadin-combo-box tabindex="1" placeholder="TabIndex 1"></vaadin-combo-box>
-      </template>
-    </vaadin-demo-snippet>
-
-
     <h3>Selecting a Value</h3>
-    <vaadin-demo-snippet id='combo-box-basic-demos-selecting-a-value'>
+    <vaadin-demo-snippet id="combo-box-basic-demos-selecting-a-value">
       <template preserve-content>
         <vaadin-combo-box id="demo2" label="Element"></vaadin-combo-box>
         <p>Selected value: <span id="selected-value"></span>.</p>
@@ -61,7 +50,7 @@
 
 
     <h3>Using as a Form Field</h3>
-    <vaadin-demo-snippet id='combo-box-basic-demos-using-as-a-form-field'>
+    <vaadin-demo-snippet id="combo-box-basic-demos-using-as-a-form-field">
       <template preserve-content>
         <iron-form>
           <form method="post">
@@ -92,7 +81,7 @@
 
 
     <h3>Change Event</h3>
-    <vaadin-demo-snippet id='combo-box-basic-demos-change-event'>
+    <vaadin-demo-snippet id="combo-box-basic-demos-change-event">
       <template preserve-content>
         <vaadin-combo-box id="changeEventDemo"></vaadin-combo-box>
         <paper-button id="setRandomValue" raised>Set random value</paper-button>
@@ -117,7 +106,37 @@
       </template>
     </vaadin-demo-snippet>
 
-  </div>
+
+    <h3>Allow Custom Values</h3>
+    <p>Allow the user to set any value for the field in addition to selecting a value from the dropdown menu.</p>
+    <vaadin-demo-snippet id="combo-box-advanced-demos-typing-custom-values">
+      <template preserve-content>
+        <vaadin-combo-box id="demo1" label="Element" allow-custom-value></vaadin-combo-box>
+        <p>Selected value: <span id="selected-value2"></span></p>
+
+        <script>
+          window.addDemoReadyListener('#combo-box-advanced-demos-typing-custom-values', function(document) {
+            var combobox = document.querySelector('#demo1');
+            combobox.items = elements;
+
+            combobox.addEventListener('value-changed', function() {
+              document.querySelector('#selected-value2').innerHTML = combobox.value;
+            });
+
+            combobox.addEventListener('custom-value-set', function(e) {
+              // Prevents setting the value property automatically.
+              e.preventDefault();
+
+              combobox.value = e.detail;
+              document.querySelector('#selected-value2').innerHTML = 'custom value "' + e.detail + '" set!';
+            });
+
+            combobox.value = 'Carbon';
+          });
+        </script>
+
+      </template>
+    </vaadin-demo-snippet>
 
   </template>
   <script>

--- a/demo/combo-box-filtering-demos.html
+++ b/demo/combo-box-filtering-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="combo-box-filtering-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -9,7 +9,7 @@
 
 
     <h3>Remote Data Source</h3>
-    <vaadin-demo-snippet id='combo-box-filtering-demos-remote-data-source'>
+    <vaadin-demo-snippet id="combo-box-filtering-demos-remote-data-source">
       <template preserve-content>
         <dom-bind>
           <template is="dom-bind">
@@ -25,7 +25,7 @@
 
     <h3>Custom Filtering</h3>
 
-    <vaadin-demo-snippet id='combo-box-filtering-demos-custom-filtering'>
+    <vaadin-demo-snippet id="combo-box-filtering-demos-custom-filtering">
       <template preserve-content>
         <custom-filter></custom-filter>
         <dom-module id="custom-filter">

--- a/demo/combo-box-item-template-demos.html
+++ b/demo/combo-box-item-template-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="combo-box-item-template-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -10,7 +10,7 @@
 
     <h3>Custom Item Template</h3>
 
-    <vaadin-demo-snippet id='combo-box-item-template-demos-custom-item-template'>
+    <vaadin-demo-snippet id="combo-box-item-template-demos-custom-item-template">
       <template preserve-content>
         <vaadin-combo-box id="elements-template-box" label="Element" item-label-path="name" item-value-path="symbol">
           <template>
@@ -33,7 +33,7 @@
 
     <h3>Focused and Selected Flags</h3>
 
-    <vaadin-demo-snippet id='combo-box-item-template-demos-focused-and-selected-flags'>
+    <vaadin-demo-snippet id="combo-box-item-template-demos-focused-and-selected-flags">
       <template preserve-content>
         <vaadin-combo-box id="elements-selected-box" label="Element" value="Carbon">
           <template>
@@ -54,7 +54,7 @@
 
     <h3>Styling Items with Custom Item Element</h3>
 
-    <vaadin-demo-snippet id='combo-box-item-template-demos-styling-items-with-custom-item-element'>
+    <vaadin-demo-snippet id="combo-box-item-template-demos-styling-items-with-custom-item-element">
       <template preserve-content>
         <!-- Step 1: Define a custom element with your template and item styles -->
 
@@ -119,7 +119,7 @@
 
     <h3>Item Template with Paper Item Elements</h3>
 
-    <vaadin-demo-snippet id='combo-box-item-template-demos-item-template-with-paper-item-elements'>
+    <vaadin-demo-snippet id="combo-box-item-template-demos-item-template-with-paper-item-elements">
       <template preserve-content>
         <vaadin-combo-box id="elements-paper-item" item-value-path="email" item-label-path="email">
           <template>

--- a/demo/combo-box-objects-demos.html
+++ b/demo/combo-box-objects-demos.html
@@ -1,6 +1,6 @@
 <dom-module id="combo-box-objects-demos">
   <template>
-    <style>
+    <style include="vaadin-component-demo-shared-styles">
        :host {
         display: block;
       }
@@ -10,7 +10,7 @@
 
     <h3>Default Label and Value</h3>
 
-    <vaadin-demo-snippet id='combo-box-objects-demos-default-label-and-value'>
+    <vaadin-demo-snippet id="combo-box-objects-demos-default-label-and-value">
       <template preserve-content>
         <vaadin-combo-box id="numbers-box" label="Number"></vaadin-combo-box>
         <p>Selected item: <span id="selected-item"></span>.</p>
@@ -42,7 +42,7 @@
 
     <h3>Setting Label and Value Path</h3>
 
-    <vaadin-demo-snippet id='combo-box-objects-demos-setting-label-and-value-path'>
+    <vaadin-demo-snippet id="combo-box-objects-demos-setting-label-and-value-path">
       <template preserve-content>
         <vaadin-combo-box id="elements-box" label="Element" item-label-path="name" item-value-path="symbol"></vaadin-combo-box>
         <p>Selected element name: <span id="element-name"></span>.</p>
@@ -73,7 +73,7 @@
 
     <h3>Object Items with the Same Value</h3>
 
-    <vaadin-demo-snippet id='combo-box-objects-demos-object-items-with-the-same-value'>
+    <vaadin-demo-snippet id="combo-box-objects-demos-object-items-with-the-same-value">
       <template preserve-content>
         <vaadin-combo-box id="country-synonyms-box" label="Element"></vaadin-combo-box>
         <p>Selected Item: <span id="country-selected-item"></span>.</p>

--- a/demo/demos.json
+++ b/demo/demos.json
@@ -2,11 +2,11 @@
   "name": "Vaadin Combo Box",
   "pages": [
   {
-    "name": "Basic Examples",
+    "name": "Basics",
     "url": "combo-box-basic-demos",
     "src": "combo-box-basic-demos.html",
     "meta": {
-      "title": "vaadin-combo-box Basic Examples",
+      "title": "Vaadin Combo Box Basic Examples",
       "description": "",
       "image": ""
      }
@@ -17,7 +17,7 @@
     "url": "combo-box-objects-demos",
     "src": "combo-box-objects-demos.html",
     "meta": {
-      "title": "vaadin-combo-box Object Items Examples",
+      "title": "Vaadin Combo Box Object Items Examples",
       "description": "",
       "image": ""
      }
@@ -28,7 +28,7 @@
     "url": "combo-box-item-template-demos",
     "src": "combo-box-item-template-demos.html",
     "meta": {
-      "title": "vaadin-combo-box Object Items Examples",
+      "title": "Vaadin Combo Box Object Items Examples",
       "description": "",
       "image": ""
      }
@@ -39,7 +39,7 @@
     "url": "combo-box-filtering-demos",
     "src": "combo-box-filtering-demos.html",
     "meta": {
-      "title": "vaadin-combo-box Remote and Custom Filtering",
+      "title": "Vaadin Combo Box Remote and Custom Filtering Examples",
       "description": "",
       "image": ""
      }
@@ -50,7 +50,7 @@
     "url": "combo-box-advanced-demos",
     "src": "combo-box-advanced-demos.html",
     "meta": {
-      "title": "vaadin-combo-box Advanced Examples",
+      "title": "Vaadin Combo Box Advanced Examples",
       "description": "",
       "image": ""
      }

--- a/demo/index.html
+++ b/demo/index.html
@@ -7,8 +7,8 @@
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
   <custom-style>
-     <style include="vaadin-component-demo-shared-styles"></style>
-   </custom-style>
+    <style include="vaadin-component-demo-shared-styles"></style>
+  </custom-style>
 </head>
 
 <body>

--- a/demo/index.html
+++ b/demo/index.html
@@ -6,11 +6,9 @@
   <title>vaadin-combo-box Examples</title>
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
 
-  <style>
-    body {
-      font-family: sans-serif;
-    }
-  </style>
+  <custom-style>
+     <style include="vaadin-component-demo-shared-styles"></style>
+   </custom-style>
 </head>
 
 <body>
@@ -29,7 +27,6 @@
   <link rel="import" href="../../iron-icons/iron-icons.html">
   <link rel="import" href="../../iron-input/iron-input.html">
   <link rel="import" href="../../paper-input/paper-input.html">
-  <link rel="import" href="../../paper-styles/default-theme.html">
   <link rel="import" href="../../vaadin-button/vaadin-button.html">
   <link rel="import" href="../vaadin-combo-box.html">
   <link rel="import" href="../../iron-form/iron-form.html">

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -29,7 +29,8 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       [part="text-field"] {
-        min-width: 100%;
+        width: 100%;
+        min-width: 0;
       }
 
       [part="clear-button"],

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -18,7 +18,6 @@ This program is available under Apache License Version 2.0, available at https:/
     <style>
       :host {
         display: inline-block;
-        width: 175px;
       }
 
       :host([hidden]) {
@@ -61,7 +60,7 @@ This program is available under Apache License Version 2.0, available at https:/
         autocomplete="off"
 
         invalid="[[invalid]]"
-        label="[[label]]"
+        label$="[[label]]"
         name="[[name]]"
         placeholder="[[placeholder]]"
         required="[[required]]"

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -279,8 +279,8 @@
         combobox.readonly = true;
       });
 
-      it('toggleIcon should be hidden when read-only', () => {
-        expect(getComputedStyle(combobox._toggleElement).display).to.equal('none');
+      it('toggleIcon should not be hidden when read-only', () => {
+        expect(getComputedStyle(combobox._toggleElement).display).not.to.equal('none');
       });
 
       it('clearIcon should be hidden when read-only', () => {

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -48,11 +48,11 @@
       });
 
       describe('Inside flexbox', () => {
-        it('combo-box should have width 175px', () => {
+        it('combo-box should stretch to fit the flex container', () => {
           const container = fixture('combobox-in-flexbox');
           const combobox = container.querySelector('vaadin-combo-box');
           expect(window.getComputedStyle(container).width).to.eql('500px');
-          expect(window.getComputedStyle(combobox).width).to.eql('175px');
+          expect(window.getComputedStyle(combobox).width).to.eql('500px');
         });
       });
 

--- a/theme/valo/vaadin-combo-box-dropdown.html
+++ b/theme/valo/vaadin-combo-box-dropdown.html
@@ -1,7 +1,7 @@
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
 
 <link rel="import" href="../../../vaadin-overlay/theme/valo/vaadin-overlay.html">
-<link rel="import" href="../../../vaadin-valo-theme/mixins/menu-overlay.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/menu-overlay.html">
 
 <dom-module id="valo-combo-box-overlay" theme-for="vaadin-combo-box-overlay">
   <template>

--- a/theme/valo/vaadin-combo-box-dropdown.html
+++ b/theme/valo/vaadin-combo-box-dropdown.html
@@ -1,12 +1,12 @@
 <link rel="import" href="../../../vaadin-valo-theme/style.html">
 
 <link rel="import" href="../../../vaadin-overlay/theme/valo/vaadin-overlay.html">
-<link rel="import" href="../../../vaadin-valo-theme/menu-overlay.html">
+<link rel="import" href="../../../vaadin-valo-theme/mixins/menu-overlay.html">
 
 <dom-module id="valo-combo-box-overlay" theme-for="vaadin-combo-box-overlay">
   <template>
-    <style>
-      [part="overlay"] {
+    <style include="valo-menu-overlay">
+      [part="content"] {
         padding: 0;
       }
 

--- a/theme/valo/vaadin-combo-box-item.html
+++ b/theme/valo/vaadin-combo-box-item.html
@@ -1,6 +1,6 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
-<link rel="import" href="../../../vaadin-valo-theme/style.html">
+<link rel="import" href="../../../vaadin-valo-styles/color.html">
+<link rel="import" href="../../../vaadin-valo-styles/spacing.html">
+<link rel="import" href="../../../vaadin-valo-styles/style.html">
 
 <link rel="import" href="../../../vaadin-item/theme/valo/vaadin-item.html">
 

--- a/theme/valo/vaadin-combo-box-item.html
+++ b/theme/valo/vaadin-combo-box-item.html
@@ -7,23 +7,23 @@
 <dom-module id="valo-combo-box-item" theme-for="vaadin-combo-box-item">
   <template>
     <style include="valo-item">
-      /* TODO duplicated from vaadin-list-box styles. Should find a way to make it DRY */
+      /* TODO partly duplicated from valo-menu-overlay styles. Should find a way to make it DRY */
 
       :host {
         cursor: pointer;
+        padding-top: var(--valo-space-xs);
+        padding-bottom: var(--valo-space-xs);
+        padding-right: calc(var(--valo-space-l) + var(--valo-border-radius) / 4);
         padding-left: calc(var(--valo-space-xs) + var(--valo-border-radius) / 4);
         -webkit-tap-highlight-color: var(--valo-primary-color-10pct);
+        /* Need to disable text wrapping because of IE11 flexbox issue https://github.com/philipwalton/flexbugs#flexbug-3 */
+        height: var(--valo-size-m);
+        white-space: nowrap;
       }
 
       /* ShadyCSS workaround */
       :host::before {
         display: block;
-      }
-
-      /* IE11 flexbox workaround */
-      ::-ms-backdrop,
-      :host {
-        height: var(--valo-size-m);
       }
 
       /* Only apply for this particular item, not nested items */
@@ -55,4 +55,3 @@
     </style>
   </template>
 </dom-module>
-

--- a/theme/valo/vaadin-combo-box.html
+++ b/theme/valo/vaadin-combo-box.html
@@ -8,11 +8,6 @@
 <dom-module id="valo-combo-box" theme-for="vaadin-combo-box">
   <template>
   <style include="valo-field-button">
-    [part="text-field"] {
-      /* TODO Relies on knowing the width and padding sizes of vaadin-text-field */
-      width: calc(10em + (0.25em + 0.375em + var(--valo-border-radius) / 4) * 2);
-    }
-
     [part="toggle-button"]::before {
       content: var(--valo-icons-dropdown);
     }

--- a/theme/valo/vaadin-combo-box.html
+++ b/theme/valo/vaadin-combo-box.html
@@ -1,6 +1,5 @@
-<link rel="import" href="../../../vaadin-valo-theme/color.html">
-<link rel="import" href="../../../vaadin-valo-theme/spacing.html">
 <link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-theme/mixins/field-button.html">
 
 <link rel="import" href="../../../vaadin-text-field/theme/valo/vaadin-text-field.html">
 <link rel="import" href="vaadin-combo-box-dropdown.html">
@@ -8,56 +7,20 @@
 
 <dom-module id="valo-combo-box" theme-for="vaadin-combo-box">
   <template>
-    <style>
-      :host([label]) {
-        margin-top: var(--valo-space-m);
-        vertical-align: var(---vaadin-text-field-vertical-align-offset);
-      }
+  <style include="valo-field-button">
+    [part="text-field"] {
+      /* TODO Relies on knowing the width and padding sizes of vaadin-text-field */
+      width: calc(10em + (0.25em + 0.375em + var(--valo-border-radius) / 4) * 2);
+    }
 
-      [part="text-field"] {
-        display: block;
-        max-width: 100%;
-      }
+    [part="toggle-button"]::before {
+      content: var(--valo-icons-dropdown);
+    }
 
-      [part$="button"] {
-        width: 24px;
-        height: 24px;
-        line-height: 24px;
-        font-size: 24px;
-        text-align: center;
-        color: var(--valo-contrast-40pct);
-        transition: 0.2s color;
-        cursor: default;
-      }
-
-      [part$="button"]:hover {
-        color: var(--valo-contrast-70pct);
-      }
-
-      [part$="button"]::before {
-        font-family: "valo-icons";
-      }
-
-      [part="toggle-button"]::before {
-        content: "\e905";
-      }
-
-      [part="clear-button"]::before {
-        content: "\e907";
-      }
-
-      /* Read-only */
-
-      :host([readonly]) [part="toggle-button"] {
-        display: none;
-      }
-
-      /* Disabled */
-
-      :host([disabled]) [part$="button"] {
-        color: var(--valo-contrast-20pct);
-      }
-    </style>
+    [part="clear-button"]::before {
+      content: var(--valo-icons-cross);
+    }
+  </style>
   </template>
 </dom-module>
 

--- a/theme/valo/vaadin-combo-box.html
+++ b/theme/valo/vaadin-combo-box.html
@@ -1,5 +1,5 @@
-<link rel="import" href="../../../vaadin-valo-theme/font-icons.html">
-<link rel="import" href="../../../vaadin-valo-theme/mixins/field-button.html">
+<link rel="import" href="../../../vaadin-valo-styles/font-icons.html">
+<link rel="import" href="../../../vaadin-valo-styles/mixins/field-button.html">
 
 <link rel="import" href="../../../vaadin-text-field/theme/valo/vaadin-text-field.html">
 <link rel="import" href="vaadin-combo-box-dropdown.html">


### PR DESCRIPTION
Use shared styles from vaadin-demo-helpers

Move ”Allow custom values” demo from advanced to basic

Fix HTML quotes

Bind to text-field label attribute instead of property. The text-field theme relies on the presence of the label attribute to ensure proper vertical alignment.

Depend on the latest text-field and valo theme updates:
- https://github.com/vaadin/vaadin-text-field/pull/181

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/589)
<!-- Reviewable:end -->