### PR TITLE
Enable polymer-linter in CI and fix some warnings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ install:
 
 before_script:
   - gulp lint version:check
+  - polymer lint ./src/*.html ./theme/*.html --rules polymer-2
   - xvfb-run -s '-screen 0 1024x768x24' wct
 
 script:

--- a/analysis.json
+++ b/analysis.json
@@ -8,12 +8,12 @@
       "sourceRange": {
         "file": "src/vaadin-combo-box.html",
         "start": {
-          "line": 329,
+          "line": 330,
           "column": 6
         },
         "end": {
-          "line": 329,
-          "column": 42
+          "line": 330,
+          "column": 54
         }
       },
       "elements": [
@@ -28,7 +28,7 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 132,
                   "column": 10
@@ -51,7 +51,7 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 138,
                   "column": 10
@@ -74,7 +74,7 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 143,
                   "column": 10
@@ -97,7 +97,7 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 148,
                   "column": 10
@@ -119,7 +119,7 @@
               "description": "When true the overlay won't disable the main content, showing\nit doesn’t change the functionality of the user interface.",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 158,
                   "column": 10
@@ -143,7 +143,7 @@
               "description": "When true move focus to the first focusable element in the overlay,\nor to the overlay if there are no focusable elements.",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 169,
                   "column": 10
@@ -165,7 +165,7 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 174,
                   "column": 10
@@ -186,7 +186,7 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 178,
                   "column": 10
@@ -207,7 +207,7 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 182,
                   "column": 10
@@ -228,7 +228,7 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 186,
                   "column": 10
@@ -249,7 +249,7 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 190,
                   "column": 10
@@ -271,13 +271,32 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 218,
+                  "line": 222,
                   "column": 6
                 },
                 "end": {
-                  "line": 229,
+                  "line": 233,
+                  "column": 7
+                }
+              },
+              "metadata": {},
+              "params": [],
+              "inheritedFrom": "Vaadin.OverlayElement"
+            },
+            {
+              "name": "_detectIosNavbar",
+              "description": "",
+              "privacy": "protected",
+              "sourceRange": {
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
+                "start": {
+                  "line": 235,
+                  "column": 6
+                },
+                "end": {
+                  "line": 252,
                   "column": 7
                 }
               },
@@ -290,13 +309,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 231,
+                  "line": 254,
                   "column": 6
                 },
                 "end": {
-                  "line": 233,
+                  "line": 256,
                   "column": 7
                 }
               },
@@ -313,13 +332,13 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 239,
+                  "line": 262,
                   "column": 6
                 },
                 "end": {
-                  "line": 245,
+                  "line": 268,
                   "column": 7
                 }
               },
@@ -336,13 +355,13 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 247,
+                  "line": 270,
                   "column": 6
                 },
                 "end": {
-                  "line": 253,
+                  "line": 281,
                   "column": 7
                 }
               },
@@ -355,13 +374,13 @@
               "description": "",
               "privacy": "public",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 255,
+                  "line": 283,
                   "column": 6
                 },
                 "end": {
-                  "line": 269,
+                  "line": 299,
                   "column": 7
                 }
               },
@@ -374,13 +393,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 271,
+                  "line": 301,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 303,
                   "column": 7
                 }
               },
@@ -397,13 +416,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 275,
+                  "line": 305,
                   "column": 6
                 },
                 "end": {
-                  "line": 277,
+                  "line": 307,
                   "column": 7
                 }
               },
@@ -420,13 +439,13 @@
               "description": "We need to listen on 'click' / 'tap' event and capture it and close the overlay before\npropagating the event to the listener in the button. Otherwise, if the clicked button would call\nopen(), this would happen: https://www.youtube.com/watch?v=Z86V_ICUCD4",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 287,
+                  "line": 317,
                   "column": 6
                 },
                 "end": {
-                  "line": 301,
+                  "line": 334,
                   "column": 7
                 }
               },
@@ -443,13 +462,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 307,
+                  "line": 340,
                   "column": 6
                 },
                 "end": {
-                  "line": 333,
+                  "line": 370,
                   "column": 7
                 }
               },
@@ -466,13 +485,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 339,
+                  "line": 376,
                   "column": 6
                 },
                 "end": {
-                  "line": 369,
+                  "line": 405,
                   "column": 7
                 }
               },
@@ -489,13 +508,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 371,
+                  "line": 414,
                   "column": 6
                 },
                 "end": {
-                  "line": 379,
+                  "line": 422,
                   "column": 7
                 }
               },
@@ -512,13 +531,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 381,
+                  "line": 424,
                   "column": 6
                 },
                 "end": {
-                  "line": 391,
+                  "line": 436,
                   "column": 7
                 }
               },
@@ -531,13 +550,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 393,
+                  "line": 438,
                   "column": 6
                 },
                 "end": {
-                  "line": 402,
+                  "line": 449,
                   "column": 7
                 }
               },
@@ -550,13 +569,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 404,
+                  "line": 451,
                   "column": 6
                 },
                 "end": {
-                  "line": 415,
+                  "line": 462,
                   "column": 7
                 }
               },
@@ -573,13 +592,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 417,
+                  "line": 464,
                   "column": 6
                 },
                 "end": {
-                  "line": 419,
+                  "line": 466,
                   "column": 7
                 }
               },
@@ -596,13 +615,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 421,
+                  "line": 468,
                   "column": 6
                 },
                 "end": {
-                  "line": 452,
+                  "line": 499,
                   "column": 7
                 }
               },
@@ -622,13 +641,13 @@
               "description": "borrowed from jqeury $(elem).is(':visible') implementation",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 455,
+                  "line": 502,
                   "column": 6
                 },
                 "end": {
-                  "line": 457,
+                  "line": 504,
                   "column": 7
                 }
               },
@@ -645,13 +664,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 459,
+                  "line": 506,
                   "column": 6
                 },
                 "end": {
-                  "line": 483,
+                  "line": 530,
                   "column": 7
                 }
               },
@@ -664,13 +683,13 @@
               "description": "",
               "privacy": "protected",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
-                  "line": 485,
+                  "line": 532,
                   "column": 6
                 },
                 "end": {
-                  "line": 489,
+                  "line": 536,
                   "column": 7
                 }
               },
@@ -721,14 +740,14 @@
             }
           },
           "privacy": "private",
-          "superclass": "HTMLElement",
+          "superclass": "Vaadin.OverlayElement",
           "name": "Vaadin.VaadinComboBoxOverlay",
           "attributes": [
             {
               "name": "opened",
               "description": "",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 132,
                   "column": 10
@@ -746,7 +765,7 @@
               "name": "template",
               "description": "",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 138,
                   "column": 10
@@ -764,7 +783,7 @@
               "name": "content",
               "description": "",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 143,
                   "column": 10
@@ -782,7 +801,7 @@
               "name": "with-backdrop",
               "description": "",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 148,
                   "column": 10
@@ -800,7 +819,7 @@
               "name": "modeless",
               "description": "When true the overlay won't disable the main content, showing\nit doesn’t change the functionality of the user interface.",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 158,
                   "column": 10
@@ -818,7 +837,7 @@
               "name": "focus-trap",
               "description": "When true move focus to the first focusable element in the overlay,\nor to the overlay if there are no focusable elements.",
               "sourceRange": {
-                "file": "../bower_components/vaadin-overlay/vaadin-overlay.html",
+                "file": "../bower_components/vaadin-overlay/src/vaadin-overlay.html",
                 "start": {
                   "line": 169,
                   "column": 10
@@ -1386,7 +1405,7 @@
             },
             {
               "name": "item",
-              "type": "(String|Object)",
+              "type": "(String | Object)",
               "description": "The item to render",
               "privacy": "public",
               "sourceRange": {
@@ -1599,7 +1618,7 @@
                 }
               },
               "metadata": {},
-              "type": "(String|Object)"
+              "type": "(String | Object)"
             },
             {
               "name": "label",
@@ -1674,11 +1693,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 123,
+                  "line": 125,
                   "column": 8
                 },
                 "end": {
-                  "line": 123,
+                  "line": 125,
                   "column": 27
                 }
               },
@@ -1697,11 +1716,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1152,
+                  "line": 1171,
                   "column": 8
                 },
                 "end": {
-                  "line": 1152,
+                  "line": 1171,
                   "column": 27
                 }
               },
@@ -1720,11 +1739,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 127,
+                  "line": 129,
                   "column": 8
                 },
                 "end": {
-                  "line": 127,
+                  "line": 129,
                   "column": 27
                 }
               },
@@ -1743,11 +1762,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 129,
+                  "line": 131,
                   "column": 8
                 },
                 "end": {
-                  "line": 129,
+                  "line": 131,
                   "column": 25
                 }
               },
@@ -1766,11 +1785,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 131,
+                  "line": 133,
                   "column": 8
                 },
                 "end": {
-                  "line": 131,
+                  "line": 133,
                   "column": 27
                 }
               },
@@ -1789,11 +1808,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1134,
+                  "line": 1153,
                   "column": 8
                 },
                 "end": {
-                  "line": 1134,
+                  "line": 1153,
                   "column": 20
                 }
               },
@@ -1812,11 +1831,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1136,
+                  "line": 1155,
                   "column": 8
                 },
                 "end": {
-                  "line": 1136,
+                  "line": 1155,
                   "column": 27
                 }
               },
@@ -1835,11 +1854,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1138,
+                  "line": 1157,
                   "column": 8
                 },
                 "end": {
-                  "line": 1138,
+                  "line": 1157,
                   "column": 23
                 }
               },
@@ -1858,11 +1877,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 139,
+                  "line": 141,
                   "column": 8
                 },
                 "end": {
-                  "line": 139,
+                  "line": 141,
                   "column": 25
                 }
               },
@@ -1881,11 +1900,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 141,
+                  "line": 143,
                   "column": 8
                 },
                 "end": {
-                  "line": 141,
+                  "line": 143,
                   "column": 31
                 }
               },
@@ -1904,11 +1923,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 143,
+                  "line": 145,
                   "column": 8
                 },
                 "end": {
-                  "line": 143,
+                  "line": 145,
                   "column": 33
                 }
               },
@@ -1927,11 +1946,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1116,
+                  "line": 1135,
                   "column": 8
                 },
                 "end": {
-                  "line": 1116,
+                  "line": 1135,
                   "column": 32
                 }
               },
@@ -1950,11 +1969,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1118,
+                  "line": 1137,
                   "column": 8
                 },
                 "end": {
-                  "line": 1118,
+                  "line": 1137,
                   "column": 34
                 }
               },
@@ -1973,11 +1992,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1120,
+                  "line": 1139,
                   "column": 8
                 },
                 "end": {
-                  "line": 1120,
+                  "line": 1139,
                   "column": 28
                 }
               },
@@ -1996,11 +2015,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1122,
+                  "line": 1141,
                   "column": 8
                 },
                 "end": {
-                  "line": 1122,
+                  "line": 1141,
                   "column": 31
                 }
               },
@@ -2019,11 +2038,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1124,
+                  "line": 1143,
                   "column": 8
                 },
                 "end": {
-                  "line": 1124,
+                  "line": 1143,
                   "column": 28
                 }
               },
@@ -2042,11 +2061,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1126,
+                  "line": 1145,
                   "column": 8
                 },
                 "end": {
-                  "line": 1126,
+                  "line": 1145,
                   "column": 35
                 }
               },
@@ -2065,11 +2084,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1128,
+                  "line": 1147,
                   "column": 8
                 },
                 "end": {
-                  "line": 1128,
+                  "line": 1147,
                   "column": 24
                 }
               },
@@ -2088,11 +2107,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1130,
+                  "line": 1149,
                   "column": 8
                 },
                 "end": {
-                  "line": 1130,
+                  "line": 1149,
                   "column": 24
                 }
               },
@@ -2111,11 +2130,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1132,
+                  "line": 1151,
                   "column": 8
                 },
                 "end": {
-                  "line": 1132,
+                  "line": 1151,
                   "column": 38
                 }
               },
@@ -2134,11 +2153,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1140,
+                  "line": 1159,
                   "column": 8
                 },
                 "end": {
-                  "line": 1140,
+                  "line": 1159,
                   "column": 30
                 }
               },
@@ -2157,11 +2176,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1142,
+                  "line": 1161,
                   "column": 8
                 },
                 "end": {
-                  "line": 1142,
+                  "line": 1161,
                   "column": 30
                 }
               },
@@ -2180,11 +2199,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1144,
+                  "line": 1163,
                   "column": 8
                 },
                 "end": {
-                  "line": 1144,
+                  "line": 1163,
                   "column": 29
                 }
               },
@@ -2203,11 +2222,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1146,
+                  "line": 1165,
                   "column": 8
                 },
                 "end": {
-                  "line": 1146,
+                  "line": 1165,
                   "column": 32
                 }
               },
@@ -2226,11 +2245,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1148,
+                  "line": 1167,
                   "column": 8
                 },
                 "end": {
-                  "line": 1148,
+                  "line": 1167,
                   "column": 30
                 }
               },
@@ -2249,11 +2268,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1150,
+                  "line": 1169,
                   "column": 8
                 },
                 "end": {
-                  "line": 1150,
+                  "line": 1169,
                   "column": 24
                 }
               },
@@ -2272,11 +2291,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1154,
+                  "line": 1173,
                   "column": 8
                 },
                 "end": {
-                  "line": 1154,
+                  "line": 1173,
                   "column": 28
                 }
               },
@@ -2295,11 +2314,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 519,
+                  "line": 560,
                   "column": 8
                 },
                 "end": {
-                  "line": 519,
+                  "line": 560,
                   "column": 23
                 }
               },
@@ -2318,11 +2337,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 521,
+                  "line": 562,
                   "column": 8
                 },
                 "end": {
-                  "line": 521,
+                  "line": 562,
                   "column": 25
                 }
               },
@@ -2341,11 +2360,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 523,
+                  "line": 564,
                   "column": 8
                 },
                 "end": {
-                  "line": 523,
+                  "line": 564,
                   "column": 22
                 }
               },
@@ -2364,11 +2383,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 525,
+                  "line": 566,
                   "column": 8
                 },
                 "end": {
-                  "line": 525,
+                  "line": 566,
                   "column": 24
                 }
               },
@@ -2381,17 +2400,17 @@
             },
             {
               "name": "root",
-              "type": "(StampedTemplate|HTMLElement|ShadowRoot)",
+              "type": "(StampedTemplate | HTMLElement | ShadowRoot)",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 527,
+                  "line": 568,
                   "column": 8
                 },
                 "end": {
-                  "line": 527,
+                  "line": 568,
                   "column": 18
                 }
               },
@@ -2404,17 +2423,17 @@
             },
             {
               "name": "$",
-              "type": "!Object.<string, !Node>",
+              "type": "!Object.<string, !Element>",
               "description": "",
               "privacy": "public",
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 529,
+                  "line": 570,
                   "column": 8
                 },
                 "end": {
-                  "line": 529,
+                  "line": 570,
                   "column": 15
                 }
               },
@@ -2464,9 +2483,9 @@
               }
             },
             {
-              "name": "loading",
-              "type": "boolean",
-              "description": "`true` when new items are being loaded.",
+              "name": "positionTarget",
+              "type": "Object",
+              "description": "The element to position/align the dropdown by.",
               "privacy": "public",
               "sourceRange": {
                 "start": {
@@ -2474,7 +2493,26 @@
                   "column": 10
                 },
                 "end": {
-                  "line": 100,
+                  "line": 97,
+                  "column": 11
+                }
+              },
+              "metadata": {
+                "polymer": {}
+              }
+            },
+            {
+              "name": "loading",
+              "type": "boolean",
+              "description": "`true` when new items are being loaded.",
+              "privacy": "public",
+              "sourceRange": {
+                "start": {
+                  "line": 102,
+                  "column": 10
+                },
+                "end": {
+                  "line": 107,
                   "column": 11
                 }
               },
@@ -2492,11 +2530,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 102,
+                  "line": 109,
                   "column": 10
                 },
                 "end": {
-                  "line": 104,
+                  "line": 111,
                   "column": 11
                 }
               },
@@ -2511,11 +2549,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 106,
+                  "line": 113,
                   "column": 10
                 },
                 "end": {
-                  "line": 108,
+                  "line": 115,
                   "column": 11
                 }
               },
@@ -2530,11 +2568,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 110,
+                  "line": 117,
                   "column": 10
                 },
                 "end": {
-                  "line": 115,
+                  "line": 122,
                   "column": 11
                 }
               },
@@ -2553,11 +2591,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 117,
+                  "line": 124,
                   "column": 10
                 },
                 "end": {
-                  "line": 120,
+                  "line": 127,
                   "column": 11
                 }
               },
@@ -2574,11 +2612,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 122,
+                  "line": 129,
                   "column": 10
                 },
                 "end": {
-                  "line": 125,
+                  "line": 132,
                   "column": 11
                 }
               },
@@ -2594,11 +2632,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 127,
+                  "line": 134,
                   "column": 10
                 },
                 "end": {
-                  "line": 130,
+                  "line": 137,
                   "column": 11
                 }
               },
@@ -2614,11 +2652,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 132,
+                  "line": 139,
                   "column": 10
                 },
                 "end": {
-                  "line": 132,
+                  "line": 139,
                   "column": 27
                 }
               },
@@ -2635,11 +2673,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2320,
+                  "line": 2366,
                   "column": 6
                 },
                 "end": {
-                  "line": 2345,
+                  "line": 2391,
                   "column": 7
                 }
               },
@@ -2664,11 +2702,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 451,
+                  "line": 452,
                   "column": 6
                 },
                 "end": {
-                  "line": 456,
+                  "line": 457,
                   "column": 7
                 }
               },
@@ -2708,11 +2746,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 465,
+                  "line": 467,
                   "column": 6
                 },
                 "end": {
-                  "line": 467,
+                  "line": 469,
                   "column": 7
                 }
               },
@@ -2734,6 +2772,9 @@
                   "description": "Listener function to add"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.TemplateStamp"
             },
             {
@@ -2743,11 +2784,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 476,
+                  "line": 479,
                   "column": 6
                 },
                 "end": {
-                  "line": 478,
+                  "line": 481,
                   "column": 7
                 }
               },
@@ -2769,6 +2810,9 @@
                   "description": "Listener function to remove"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.TemplateStamp"
             },
             {
@@ -2778,11 +2822,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 723,
+                  "line": 754,
                   "column": 6
                 },
                 "end": {
-                  "line": 731,
+                  "line": 762,
                   "column": 7
                 }
               },
@@ -2813,11 +2857,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 543,
+                  "line": 584,
                   "column": 6
                 },
                 "end": {
-                  "line": 577,
+                  "line": 618,
                   "column": 7
                 }
               },
@@ -2832,11 +2876,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1184,
+                  "line": 1203,
                   "column": 6
                 },
                 "end": {
-                  "line": 1188,
+                  "line": 1207,
                   "column": 7
                 }
               },
@@ -2857,11 +2901,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1197,
+                  "line": 1216,
                   "column": 6
                 },
                 "end": {
-                  "line": 1206,
+                  "line": 1225,
                   "column": 7
                 }
               },
@@ -2882,11 +2926,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 236,
+                  "line": 242,
                   "column": 6
                 },
                 "end": {
-                  "line": 240,
+                  "line": 246,
                   "column": 7
                 }
               },
@@ -2903,6 +2947,9 @@
                   "description": "of the attribute."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -2912,11 +2959,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 252,
+                  "line": 259,
                   "column": 6
                 },
                 "end": {
-                  "line": 258,
+                  "line": 265,
                   "column": 7
                 }
               },
@@ -2938,6 +2985,9 @@
                   "description": "type to deserialize to."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -2947,11 +2997,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 267,
+                  "line": 275,
                   "column": 6
                 },
                 "end": {
-                  "line": 273,
+                  "line": 281,
                   "column": 7
                 }
               },
@@ -2973,6 +3023,9 @@
                   "description": "Property value to refect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -2982,11 +3035,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 287,
+                  "line": 296,
                   "column": 6
                 },
                 "end": {
-                  "line": 294,
+                  "line": 303,
                   "column": 7
                 }
               },
@@ -3008,6 +3061,9 @@
                   "description": "Attribute name to serialize to."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -3017,11 +3073,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 306,
+                  "line": 315,
                   "column": 6
                 },
                 "end": {
-                  "line": 326,
+                  "line": 335,
                   "column": 7
                 }
               },
@@ -3034,7 +3090,7 @@
                 }
               ],
               "return": {
-                "type": "(string|undefined)",
+                "type": "(string | undefined)",
                 "desc": "String serialized from the provided property value."
               },
               "inheritedFrom": "Polymer.PropertyAccessors"
@@ -3046,11 +3102,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 345,
+                  "line": 354,
                   "column": 6
                 },
                 "end": {
-                  "line": 387,
+                  "line": 397,
                   "column": 7
                 }
               },
@@ -3080,11 +3136,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 411,
+                  "line": 422,
                   "column": 6
                 },
                 "end": {
-                  "line": 431,
+                  "line": 442,
                   "column": 7
                 }
               },
@@ -3101,6 +3157,9 @@
                   "description": "When true, no setter is created; the\n  protected `_setProperty` function must be used to set the property"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -3110,11 +3169,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 439,
+                  "line": 450,
                   "column": 6
                 },
                 "end": {
-                  "line": 441,
+                  "line": 452,
                   "column": 7
                 }
               },
@@ -3139,11 +3198,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1473,
+                  "line": 1495,
                   "column": 6
                 },
                 "end": {
-                  "line": 1477,
+                  "line": 1499,
                   "column": 7
                 }
               },
@@ -3165,11 +3224,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1436,
+                  "line": 1458,
                   "column": 6
                 },
                 "end": {
-                  "line": 1465,
+                  "line": 1487,
                   "column": 7
                 }
               },
@@ -3204,11 +3263,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 493,
+                  "line": 505,
                   "column": 6
                 },
                 "end": {
-                  "line": 495,
+                  "line": 507,
                   "column": 7
                 }
               },
@@ -3233,11 +3292,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1487,
+                  "line": 1509,
                   "column": 6
                 },
                 "end": {
-                  "line": 1491,
+                  "line": 1513,
                   "column": 7
                 }
               },
@@ -3252,16 +3311,19 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 523,
+                  "line": 538,
                   "column": 6
                 },
                 "end": {
-                  "line": 532,
+                  "line": 547,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -3271,16 +3333,19 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 543,
+                  "line": 558,
                   "column": 6
                 },
                 "end": {
-                  "line": 551,
+                  "line": 566,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -3289,11 +3354,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 140,
+                  "line": 147,
                   "column": 6
                 },
                 "end": {
-                  "line": 156,
+                  "line": 163,
                   "column": 7
                 }
               },
@@ -3307,11 +3372,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1626,
+                  "line": 1652,
                   "column": 6
                 },
                 "end": {
-                  "line": 1659,
+                  "line": 1685,
                   "column": 7
                 }
               },
@@ -3336,11 +3401,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 606,
+                  "line": 621,
                   "column": 6
                 },
                 "end": {
-                  "line": 609,
+                  "line": 624,
                   "column": 7
                 }
               },
@@ -3375,11 +3440,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1220,
+                  "line": 1240,
                   "column": 6
                 },
                 "end": {
-                  "line": 1228,
+                  "line": 1248,
                   "column": 7
                 }
               },
@@ -3401,6 +3466,9 @@
                   "description": "Effect metadata object"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3410,11 +3478,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1237,
+                  "line": 1258,
                   "column": 6
                 },
                 "end": {
-                  "line": 1243,
+                  "line": 1264,
                   "column": 7
                 }
               },
@@ -3436,6 +3504,9 @@
                   "description": "Effect metadata object to remove"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3445,11 +3516,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1254,
+                  "line": 1275,
                   "column": 6
                 },
                 "end": {
-                  "line": 1257,
+                  "line": 1278,
                   "column": 7
                 }
               },
@@ -3479,11 +3550,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1267,
+                  "line": 1288,
                   "column": 6
                 },
                 "end": {
-                  "line": 1269,
+                  "line": 1290,
                   "column": 7
                 }
               },
@@ -3508,11 +3579,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1279,
+                  "line": 1300,
                   "column": 6
                 },
                 "end": {
-                  "line": 1281,
+                  "line": 1302,
                   "column": 7
                 }
               },
@@ -3537,11 +3608,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1291,
+                  "line": 1312,
                   "column": 6
                 },
                 "end": {
-                  "line": 1293,
+                  "line": 1314,
                   "column": 7
                 }
               },
@@ -3566,11 +3637,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1303,
+                  "line": 1324,
                   "column": 6
                 },
                 "end": {
-                  "line": 1305,
+                  "line": 1326,
                   "column": 7
                 }
               },
@@ -3595,11 +3666,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1337,
+                  "line": 1358,
                   "column": 6
                 },
                 "end": {
-                  "line": 1369,
+                  "line": 1390,
                   "column": 7
                 }
               },
@@ -3607,7 +3678,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(number|string)>)",
+                  "type": "(string | !Array.<(number | string)>)",
                   "description": "Path to set"
                 },
                 {
@@ -3639,11 +3710,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1391,
+                  "line": 1413,
                   "column": 6
                 },
                 "end": {
-                  "line": 1399,
+                  "line": 1421,
                   "column": 7
                 }
               },
@@ -3665,6 +3736,9 @@
                   "description": "The value to set"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3674,11 +3748,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1501,
+                  "line": 1524,
                   "column": 6
                 },
                 "end": {
-                  "line": 1506,
+                  "line": 1529,
                   "column": 7
                 }
               },
@@ -3690,6 +3764,9 @@
                   "description": "PropertyEffects client to enqueue"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3699,16 +3776,19 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1514,
+                  "line": 1538,
                   "column": 6
                 },
                 "end": {
-                  "line": 1525,
+                  "line": 1549,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3718,11 +3798,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1539,
+                  "line": 1563,
                   "column": 6
                 },
                 "end": {
-                  "line": 1552,
+                  "line": 1576,
                   "column": 7
                 }
               },
@@ -3737,11 +3817,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 668,
+                  "line": 699,
                   "column": 6
                 },
                 "end": {
-                  "line": 677,
+                  "line": 708,
                   "column": 7
                 }
               },
@@ -3756,11 +3836,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1579,
+                  "line": 1605,
                   "column": 6
                 },
                 "end": {
-                  "line": 1590,
+                  "line": 1616,
                   "column": 7
                 }
               },
@@ -3777,6 +3857,9 @@
                   "description": "When true, any private values set in\n  `props` will be set. By default, `setProperties` will not set\n  `readOnly: true` root properties."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3786,11 +3869,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1670,
+                  "line": 1697,
                   "column": 6
                 },
                 "end": {
-                  "line": 1680,
+                  "line": 1707,
                   "column": 7
                 }
               },
@@ -3812,6 +3895,9 @@
                   "description": "True with `props` contains one or more paths"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3821,11 +3907,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1690,
+                  "line": 1718,
                   "column": 6
                 },
                 "end": {
-                  "line": 1695,
+                  "line": 1723,
                   "column": 7
                 }
               },
@@ -3833,15 +3919,18 @@
               "params": [
                 {
                   "name": "to",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to link."
                 },
                 {
                   "name": "from",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Source path to link."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3851,11 +3940,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1706,
+                  "line": 1735,
                   "column": 6
                 },
                 "end": {
-                  "line": 1711,
+                  "line": 1740,
                   "column": 7
                 }
               },
@@ -3863,10 +3952,13 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Target path to unlink."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3876,11 +3968,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1742,
+                  "line": 1772,
                   "column": 6
                 },
                 "end": {
-                  "line": 1746,
+                  "line": 1776,
                   "column": 7
                 }
               },
@@ -3897,6 +3989,9 @@
                   "description": "Array of splice records indicating ordered\n  changes that occurred to the array. Each record should have the\n  following fields:\n   * index: index at which the change occurred\n   * removed: array of items that were removed from this index\n   * addedCount: number of new items added at this index\n   * object: a reference to the array in question\n   * type: the string literal 'splice'\n\n  Note that splice records _must_ be normalized such that they are\n  reported in index order (raw results from `Object.observe` are not\n  ordered and must be normalized/merged before notifying)."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3906,11 +4001,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1767,
+                  "line": 1797,
                   "column": 6
                 },
                 "end": {
-                  "line": 1769,
+                  "line": 1799,
                   "column": 7
                 }
               },
@@ -3918,7 +4013,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to read.  The path may be specified as a string (e.g. `foo.bar.baz`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `users.12.name` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3940,11 +4035,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1791,
+                  "line": 1822,
                   "column": 6
                 },
                 "end": {
-                  "line": 1801,
+                  "line": 1832,
                   "column": 7
                 }
               },
@@ -3952,7 +4047,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to the value\n  to write.  The path may be specified as a string (e.g. `'foo.bar.baz'`)\n  or an array of path parts (e.g. `['foo.bar', 'baz']`).  Note that\n  bracketed expressions are not supported; string-based path parts\n  *must* be separated by dots.  Note that when dereferencing array\n  indices, the index may be used as a dotted part directly\n  (e.g. `'users.12.name'` or `['users', 12, 'name']`)."
                 },
                 {
@@ -3966,6 +4061,9 @@
                   "description": "Root object from which the path is evaluated.\n  When specified, no notification will occur."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -3975,11 +4073,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1817,
+                  "line": 1848,
                   "column": 6
                 },
                 "end": {
-                  "line": 1826,
+                  "line": 1857,
                   "column": 7
                 }
               },
@@ -3987,11 +4085,14 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
-                  "name": "...items"
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to push onto array"
                 }
               ],
               "return": {
@@ -4007,11 +4108,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1841,
+                  "line": 1872,
                   "column": 6
                 },
                 "end": {
-                  "line": 1850,
+                  "line": 1881,
                   "column": 7
                 }
               },
@@ -4019,7 +4120,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -4036,11 +4137,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1869,
+                  "line": 1900,
                   "column": 6
                 },
                 "end": {
-                  "line": 1886,
+                  "line": 1917,
                   "column": 7
                 }
               },
@@ -4048,7 +4149,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
@@ -4062,7 +4163,10 @@
                   "description": "Number of items to remove."
                 },
                 {
-                  "name": "...items"
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert into array."
                 }
               ],
               "return": {
@@ -4078,11 +4182,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1901,
+                  "line": 1932,
                   "column": 6
                 },
                 "end": {
-                  "line": 1910,
+                  "line": 1941,
                   "column": 7
                 }
               },
@@ -4090,7 +4194,7 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 }
               ],
@@ -4107,11 +4211,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1926,
+                  "line": 1957,
                   "column": 6
                 },
                 "end": {
-                  "line": 1934,
+                  "line": 1965,
                   "column": 7
                 }
               },
@@ -4119,11 +4223,14 @@
               "params": [
                 {
                   "name": "path",
-                  "type": "(string|!Array.<(string|number)>)",
+                  "type": "(string | !Array.<(string | number)>)",
                   "description": "Path to array."
                 },
                 {
-                  "name": "...items"
+                  "name": "items",
+                  "type": "...*",
+                  "rest": true,
+                  "description": "Items to insert info array"
                 }
               ],
               "return": {
@@ -4139,11 +4246,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1948,
+                  "line": 1980,
                   "column": 6
                 },
                 "end": {
-                  "line": 1965,
+                  "line": 1997,
                   "column": 7
                 }
               },
@@ -4160,6 +4267,9 @@
                   "description": "Value at the path (optional)."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4169,11 +4279,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1977,
+                  "line": 2010,
                   "column": 6
                 },
                 "end": {
-                  "line": 1984,
+                  "line": 2017,
                   "column": 7
                 }
               },
@@ -4190,6 +4300,9 @@
                   "description": "Creates a custom protected setter\n  when `true`."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4199,11 +4312,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 1997,
+                  "line": 2031,
                   "column": 6
                 },
                 "end": {
-                  "line": 2007,
+                  "line": 2041,
                   "column": 7
                 }
               },
@@ -4215,9 +4328,9 @@
                   "description": "Property name"
                 },
                 {
-                  "name": "methodName",
-                  "type": "string",
-                  "description": "Name of observer method to call"
+                  "name": "method",
+                  "type": "(string | function (*, *))",
+                  "description": "Function or name of observer method to call"
                 },
                 {
                   "name": "dynamicFn",
@@ -4225,6 +4338,9 @@
                   "description": "Whether the method name should be included as\n  a dependency to the effect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4234,11 +4350,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2019,
+                  "line": 2054,
                   "column": 6
                 },
                 "end": {
-                  "line": 2025,
+                  "line": 2060,
                   "column": 7
                 }
               },
@@ -4251,10 +4367,13 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4264,11 +4383,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2035,
+                  "line": 2071,
                   "column": 6
                 },
                 "end": {
-                  "line": 2043,
+                  "line": 2079,
                   "column": 7
                 }
               },
@@ -4280,6 +4399,9 @@
                   "description": "Property name"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4289,11 +4411,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2053,
+                  "line": 2090,
                   "column": 6
                 },
                 "end": {
-                  "line": 2066,
+                  "line": 2103,
                   "column": 7
                 }
               },
@@ -4305,6 +4427,9 @@
                   "description": "Property name"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4314,11 +4439,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2079,
+                  "line": 2117,
                   "column": 6
                 },
                 "end": {
-                  "line": 2085,
+                  "line": 2123,
                   "column": 7
                 }
               },
@@ -4336,10 +4461,13 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4349,11 +4477,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2255,
+                  "line": 2300,
                   "column": 6
                 },
                 "end": {
-                  "line": 2278,
+                  "line": 2323,
                   "column": 7
                 }
               },
@@ -4383,11 +4511,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2355,
+                  "line": 2402,
                   "column": 6
                 },
                 "end": {
-                  "line": 2376,
+                  "line": 2423,
                   "column": 7
                 }
               },
@@ -4399,6 +4527,9 @@
                   "description": "DocumentFragment previously returned\n  from `_stampTemplate` associated with the nodes to be removed"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -4408,11 +4539,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 633,
+                  "line": 664,
                   "column": 6
                 },
                 "end": {
-                  "line": 638,
+                  "line": 669,
                   "column": 7
                 }
               },
@@ -4427,11 +4558,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 644,
+                  "line": 675,
                   "column": 6
                 },
                 "end": {
-                  "line": 644,
+                  "line": 675,
                   "column": 31
                 }
               },
@@ -4446,11 +4577,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 691,
+                  "line": 722,
                   "column": 6
                 },
                 "end": {
-                  "line": 707,
+                  "line": 738,
                   "column": 7
                 }
               },
@@ -4475,11 +4606,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 750,
+                  "line": 782,
                   "column": 6
                 },
                 "end": {
-                  "line": 754,
+                  "line": 786,
                   "column": 7
                 }
               },
@@ -4491,6 +4622,9 @@
                   "description": "Bag of custom property key/values to\n  apply to this element."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.ElementMixin"
             },
             {
@@ -4500,11 +4634,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 767,
+                  "line": 799,
                   "column": 6
                 },
                 "end": {
-                  "line": 772,
+                  "line": 804,
                   "column": 7
                 }
               },
@@ -4533,11 +4667,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 158,
+                  "line": 165,
                   "column": 6
                 },
                 "end": {
-                  "line": 161,
+                  "line": 168,
                   "column": 7
                 }
               },
@@ -4554,11 +4688,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 163,
+                  "line": 170,
                   "column": 6
                 },
                 "end": {
-                  "line": 169,
+                  "line": 176,
                   "column": 7
                 }
               },
@@ -4575,11 +4709,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 171,
+                  "line": 178,
                   "column": 6
                 },
                 "end": {
-                  "line": 173,
+                  "line": 180,
                   "column": 7
                 }
               },
@@ -4596,11 +4730,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 175,
+                  "line": 182,
                   "column": 6
                 },
                 "end": {
-                  "line": 193,
+                  "line": 200,
                   "column": 7
                 }
               },
@@ -4613,11 +4747,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 195,
+                  "line": 202,
                   "column": 6
                 },
                 "end": {
-                  "line": 205,
+                  "line": 212,
                   "column": 7
                 }
               },
@@ -4634,11 +4768,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 207,
+                  "line": 214,
                   "column": 6
                 },
                 "end": {
-                  "line": 211,
+                  "line": 218,
                   "column": 7
                 }
               },
@@ -4655,11 +4789,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 213,
+                  "line": 220,
                   "column": 6
                 },
                 "end": {
-                  "line": 215,
+                  "line": 222,
                   "column": 7
                 }
               },
@@ -4679,11 +4813,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 217,
+                  "line": 224,
                   "column": 6
                 },
                 "end": {
-                  "line": 223,
+                  "line": 230,
                   "column": 7
                 }
               },
@@ -4700,11 +4834,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 229,
+                  "line": 236,
                   "column": 6
                 },
                 "end": {
-                  "line": 240,
+                  "line": 247,
                   "column": 7
                 }
               },
@@ -4724,11 +4858,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 246,
+                  "line": 253,
                   "column": 6
                 },
                 "end": {
-                  "line": 252,
+                  "line": 259,
                   "column": 7
                 }
               },
@@ -4748,11 +4882,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 254,
+                  "line": 261,
                   "column": 6
                 },
                 "end": {
-                  "line": 256,
+                  "line": 263,
                   "column": 7
                 }
               },
@@ -4772,11 +4906,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 258,
+                  "line": 265,
                   "column": 6
                 },
                 "end": {
-                  "line": 260,
+                  "line": 267,
                   "column": 7
                 }
               },
@@ -4796,11 +4930,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 262,
+                  "line": 269,
                   "column": 6
                 },
                 "end": {
-                  "line": 264,
+                  "line": 271,
                   "column": 7
                 }
               },
@@ -4817,11 +4951,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 266,
+                  "line": 273,
                   "column": 6
                 },
                 "end": {
-                  "line": 270,
+                  "line": 277,
                   "column": 7
                 }
               },
@@ -4838,11 +4972,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 272,
+                  "line": 279,
                   "column": 6
                 },
                 "end": {
-                  "line": 303,
+                  "line": 310,
                   "column": 7
                 }
               },
@@ -4859,11 +4993,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 305,
+                  "line": 312,
                   "column": 6
                 },
                 "end": {
-                  "line": 307,
+                  "line": 314,
                   "column": 7
                 }
               },
@@ -4876,11 +5010,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 309,
+                  "line": 316,
                   "column": 6
                 },
                 "end": {
-                  "line": 313,
+                  "line": 320,
                   "column": 7
                 }
               },
@@ -4893,11 +5027,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 320,
+                  "line": 327,
                   "column": 6
                 },
                 "end": {
-                  "line": 333,
+                  "line": 340,
                   "column": 7
                 }
               },
@@ -4910,11 +5044,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 335,
+                  "line": 342,
                   "column": 6
                 },
                 "end": {
-                  "line": 338,
+                  "line": 345,
                   "column": 7
                 }
               },
@@ -4927,11 +5061,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 356,
+                  "line": 363,
                   "column": 6
                 },
                 "end": {
-                  "line": 368,
+                  "line": 375,
                   "column": 7
                 }
               },
@@ -4944,11 +5078,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 370,
+                  "line": 377,
                   "column": 6
                 },
                 "end": {
-                  "line": 375,
+                  "line": 382,
                   "column": 7
                 }
               },
@@ -4965,11 +5099,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 377,
+                  "line": 384,
                   "column": 6
                 },
                 "end": {
-                  "line": 381,
+                  "line": 388,
                   "column": 7
                 }
               },
@@ -4986,11 +5120,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 383,
+                  "line": 390,
                   "column": 6
                 },
                 "end": {
-                  "line": 385,
+                  "line": 392,
                   "column": 7
                 }
               },
@@ -5007,11 +5141,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 387,
+                  "line": 394,
                   "column": 6
                 },
                 "end": {
-                  "line": 389,
+                  "line": 396,
                   "column": 7
                 }
               },
@@ -5068,11 +5202,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 783,
+                  "line": 815,
                   "column": 6
                 },
                 "end": {
-                  "line": 786,
+                  "line": 818,
                   "column": 7
                 }
               },
@@ -5097,11 +5231,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2395,
+                  "line": 2442,
                   "column": 6
                 },
                 "end": {
-                  "line": 2409,
+                  "line": 2456,
                   "column": 7
                 }
               },
@@ -5136,11 +5270,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 257,
+                  "line": 258,
                   "column": 6
                 },
                 "end": {
-                  "line": 294,
+                  "line": 295,
                   "column": 7
                 }
               },
@@ -5162,6 +5296,9 @@
                   "description": "Node metadata for current template."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.TemplateStamp"
             },
             {
@@ -5171,11 +5308,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2482,
+                  "line": 2529,
                   "column": 6
                 },
                 "end": {
-                  "line": 2492,
+                  "line": 2539,
                   "column": 7
                 }
               },
@@ -5210,11 +5347,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 332,
+                  "line": 333,
                   "column": 6
                 },
                 "end": {
-                  "line": 341,
+                  "line": 342,
                   "column": 7
                 }
               },
@@ -5249,11 +5386,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2430,
+                  "line": 2477,
                   "column": 6
                 },
                 "end": {
-                  "line": 2466,
+                  "line": 2513,
                   "column": 7
                 }
               },
@@ -5298,11 +5435,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/template-stamp.html",
                 "start": {
-                  "line": 387,
+                  "line": 388,
                   "column": 6
                 },
                 "end": {
-                  "line": 390,
+                  "line": 391,
                   "column": 7
                 }
               },
@@ -5327,16 +5464,19 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-accessors.html",
                 "start": {
-                  "line": 113,
+                  "line": 115,
                   "column": 6
                 },
                 "end": {
-                  "line": 118,
+                  "line": 120,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyAccessors"
             },
             {
@@ -5346,11 +5486,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2124,
+                  "line": 2163,
                   "column": 6
                 },
                 "end": {
-                  "line": 2126,
+                  "line": 2165,
                   "column": 7
                 }
               },
@@ -5372,6 +5512,9 @@
                   "description": "Effect metadata object"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5381,11 +5524,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2137,
+                  "line": 2177,
                   "column": 6
                 },
                 "end": {
-                  "line": 2139,
+                  "line": 2179,
                   "column": 7
                 }
               },
@@ -5397,9 +5540,9 @@
                   "description": "Property name"
                 },
                 {
-                  "name": "methodName",
-                  "type": "string",
-                  "description": "Name of observer method to call"
+                  "name": "method",
+                  "type": "(string | function (*, *))",
+                  "description": "Function or name of observer method to call"
                 },
                 {
                   "name": "dynamicFn",
@@ -5407,6 +5550,9 @@
                   "description": "Whether the method name should be included as\n  a dependency to the effect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5416,11 +5562,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2153,
+                  "line": 2194,
                   "column": 6
                 },
                 "end": {
-                  "line": 2155,
+                  "line": 2196,
                   "column": 7
                 }
               },
@@ -5433,10 +5579,14 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
-                  "description": "Boolean or object map indicating\n  whether method names should be included as a dependency to the effect."
+                  "type": "(boolean | Object)=",
+                  "description": "Boolean or object map indicating"
                 }
               ],
+              "return": {
+                "type": "void",
+                "desc": "whether method names should be included as a dependency to the effect."
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5446,11 +5596,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2164,
+                  "line": 2206,
                   "column": 6
                 },
                 "end": {
-                  "line": 2166,
+                  "line": 2208,
                   "column": 7
                 }
               },
@@ -5462,6 +5612,9 @@
                   "description": "Property name"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5471,11 +5624,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2183,
+                  "line": 2226,
                   "column": 6
                 },
                 "end": {
-                  "line": 2185,
+                  "line": 2228,
                   "column": 7
                 }
               },
@@ -5492,6 +5645,9 @@
                   "description": "Creates a custom protected setter\n  when `true`."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5501,11 +5657,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2194,
+                  "line": 2238,
                   "column": 6
                 },
                 "end": {
-                  "line": 2196,
+                  "line": 2240,
                   "column": 7
                 }
               },
@@ -5517,6 +5673,9 @@
                   "description": "Property name"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5526,11 +5685,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2211,
+                  "line": 2256,
                   "column": 6
                 },
                 "end": {
-                  "line": 2213,
+                  "line": 2258,
                   "column": 7
                 }
               },
@@ -5548,10 +5707,13 @@
                 },
                 {
                   "name": "dynamicFn",
-                  "type": "(boolean|Object)=",
+                  "type": "(boolean | Object)=",
                   "description": "Boolean or object map indicating whether\n  method names should be included as a dependency to the effect."
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5561,11 +5723,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2227,
+                  "line": 2272,
                   "column": 6
                 },
                 "end": {
-                  "line": 2229,
+                  "line": 2274,
                   "column": 7
                 }
               },
@@ -5590,11 +5752,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2292,
+                  "line": 2338,
                   "column": 6
                 },
                 "end": {
-                  "line": 2298,
+                  "line": 2344,
                   "column": 7
                 }
               },
@@ -5616,6 +5778,9 @@
                   "description": "Effect metadata object"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.PropertyEffects"
             },
             {
@@ -5625,11 +5790,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2527,
+                  "line": 2574,
                   "column": 6
                 },
                 "end": {
-                  "line": 2592,
+                  "line": 2639,
                   "column": 7
                 }
               },
@@ -5659,11 +5824,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/property-effects.html",
                 "start": {
-                  "line": 2608,
+                  "line": 2655,
                   "column": 6
                 },
                 "end": {
-                  "line": 2625,
+                  "line": 2672,
                   "column": 7
                 }
               },
@@ -5713,44 +5878,42 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 441,
+                  "line": 482,
                   "column": 6
                 },
                 "end": {
-                  "line": 445,
+                  "line": 486,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.ElementMixin"
             },
             {
               "name": "_processStyleText",
-              "description": "Gather style text for the template",
+              "description": "Gather style text for a style element in the template.",
               "privacy": "protected",
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 588,
+                  "line": 628,
                   "column": 6
                 },
                 "end": {
-                  "line": 591,
+                  "line": 630,
                   "column": 7
                 }
               },
               "metadata": {},
               "params": [
                 {
-                  "name": "is",
+                  "name": "cssText",
                   "type": "string",
-                  "description": "Tag name for this element"
-                },
-                {
-                  "name": "template",
-                  "type": "!HTMLTemplateElement",
-                  "description": "Template to process"
+                  "description": "Text containing styling to process"
                 },
                 {
                   "name": "baseURI",
@@ -5760,7 +5923,7 @@
               ],
               "return": {
                 "type": "string",
-                "desc": "The combined CSS text"
+                "desc": "The processed CSS text"
               },
               "inheritedFrom": "Polymer.ElementMixin"
             },
@@ -5771,11 +5934,11 @@
               "sourceRange": {
                 "file": "../bower_components/polymer/lib/mixins/element-mixin.html",
                 "start": {
-                  "line": 602,
+                  "line": 641,
                   "column": 6
                 },
                 "end": {
-                  "line": 621,
+                  "line": 652,
                   "column": 7
                 }
               },
@@ -5785,13 +5948,11 @@
                   "name": "is",
                   "type": "string",
                   "description": "Tag name (or type extension name) for this element"
-                },
-                {
-                  "name": "ext",
-                  "type": "string=",
-                  "description": "For type extensions, the tag name that was extended"
                 }
               ],
+              "return": {
+                "type": "void"
+              },
               "inheritedFrom": "Polymer.ElementMixin"
             }
           ],
@@ -5803,12 +5964,12 @@
               "column": 4
             },
             "end": {
-              "line": 390,
+              "line": 397,
               "column": 5
             }
           },
           "privacy": "private",
-          "superclass": "HTMLElement",
+          "superclass": "Polymer.Element",
           "name": "Vaadin.ComboBoxOverlayElement",
           "attributes": [
             {
@@ -5844,15 +6005,31 @@
               "type": "boolean"
             },
             {
-              "name": "loading",
-              "description": "`true` when new items are being loaded.",
+              "name": "position-target",
+              "description": "The element to position/align the dropdown by.",
               "sourceRange": {
                 "start": {
                   "line": 95,
                   "column": 10
                 },
                 "end": {
-                  "line": 100,
+                  "line": 97,
+                  "column": 11
+                }
+              },
+              "metadata": {},
+              "type": "Object"
+            },
+            {
+              "name": "loading",
+              "description": "`true` when new items are being loaded.",
+              "sourceRange": {
+                "start": {
+                  "line": 102,
+                  "column": 10
+                },
+                "end": {
+                  "line": 107,
                   "column": 11
                 }
               },
@@ -7877,11 +8054,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 216,
+                  "line": 217,
                   "column": 12
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 13
                 }
               },
@@ -7897,11 +8074,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 254,
+                  "line": 255,
                   "column": 12
                 },
                 "end": {
-                  "line": 257,
+                  "line": 258,
                   "column": 13
                 }
               },
@@ -8312,11 +8489,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 12
                 },
                 "end": {
-                  "line": 203,
+                  "line": 204,
                   "column": 13
                 }
               },
@@ -8331,11 +8508,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 208,
+                  "line": 209,
                   "column": 12
                 },
                 "end": {
-                  "line": 211,
+                  "line": 212,
                   "column": 13
                 }
               },
@@ -8351,11 +8528,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 225,
                   "column": 12
                 },
                 "end": {
-                  "line": 226,
+                  "line": 227,
                   "column": 13
                 }
               },
@@ -8370,11 +8547,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 231,
+                  "line": 232,
                   "column": 12
                 },
                 "end": {
-                  "line": 233,
+                  "line": 234,
                   "column": 13
                 }
               },
@@ -8389,11 +8566,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 238,
+                  "line": 239,
                   "column": 12
                 },
                 "end": {
-                  "line": 240,
+                  "line": 241,
                   "column": 13
                 }
               },
@@ -8408,11 +8585,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 242,
+                  "line": 243,
                   "column": 12
                 },
                 "end": {
-                  "line": 244,
+                  "line": 245,
                   "column": 13
                 }
               },
@@ -8427,11 +8604,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 249,
+                  "line": 250,
                   "column": 12
                 },
                 "end": {
-                  "line": 252,
+                  "line": 253,
                   "column": 13
                 }
               },
@@ -8448,11 +8625,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 277,
+                  "line": 278,
                   "column": 8
                 },
                 "end": {
-                  "line": 288,
+                  "line": 289,
                   "column": 9
                 }
               },
@@ -9490,11 +9667,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 265,
+                  "line": 266,
                   "column": 8
                 },
                 "end": {
-                  "line": 275,
+                  "line": 276,
                   "column": 9
                 }
               },
@@ -9514,11 +9691,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 290,
+                  "line": 291,
                   "column": 8
                 },
                 "end": {
-                  "line": 293,
+                  "line": 294,
                   "column": 9
                 }
               },
@@ -9531,11 +9708,11 @@
               "privacy": "public",
               "sourceRange": {
                 "start": {
-                  "line": 295,
+                  "line": 296,
                   "column": 8
                 },
                 "end": {
-                  "line": 298,
+                  "line": 299,
                   "column": 9
                 }
               },
@@ -9548,11 +9725,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 300,
+                  "line": 301,
                   "column": 8
                 },
                 "end": {
-                  "line": 302,
+                  "line": 303,
                   "column": 9
                 }
               },
@@ -9565,11 +9742,11 @@
               "privacy": "protected",
               "sourceRange": {
                 "start": {
-                  "line": 304,
+                  "line": 305,
                   "column": 8
                 },
                 "end": {
-                  "line": 309,
+                  "line": 310,
                   "column": 9
                 }
               },
@@ -9611,11 +9788,11 @@
           "metadata": {},
           "sourceRange": {
             "start": {
-              "line": 185,
+              "line": 186,
               "column": 6
             },
             "end": {
-              "line": 322,
+              "line": 323,
               "column": 7
             }
           },
@@ -9646,11 +9823,11 @@
               "description": "Set to true to disable this input.",
               "sourceRange": {
                 "start": {
-                  "line": 216,
+                  "line": 217,
                   "column": 12
                 },
                 "end": {
-                  "line": 219,
+                  "line": 220,
                   "column": 13
                 }
               },
@@ -9662,11 +9839,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 254,
+                  "line": 255,
                   "column": 12
                 },
                 "end": {
-                  "line": 257,
+                  "line": 258,
                   "column": 13
                 }
               },
@@ -9876,11 +10053,11 @@
               "description": "The label for this element.",
               "sourceRange": {
                 "start": {
-                  "line": 200,
+                  "line": 201,
                   "column": 12
                 },
                 "end": {
-                  "line": 203,
+                  "line": 204,
                   "column": 13
                 }
               },
@@ -9892,11 +10069,11 @@
               "description": "Set to true to mark the input as required.",
               "sourceRange": {
                 "start": {
-                  "line": 208,
+                  "line": 209,
                   "column": 12
                 },
                 "end": {
-                  "line": 211,
+                  "line": 212,
                   "column": 13
                 }
               },
@@ -9908,11 +10085,11 @@
               "description": "Set to true to prevent the user from entering invalid input.",
               "sourceRange": {
                 "start": {
-                  "line": 224,
+                  "line": 225,
                   "column": 12
                 },
                 "end": {
-                  "line": 226,
+                  "line": 227,
                   "column": 13
                 }
               },
@@ -9924,11 +10101,11 @@
               "description": "A pattern to validate the `input` with.",
               "sourceRange": {
                 "start": {
-                  "line": 231,
+                  "line": 232,
                   "column": 12
                 },
                 "end": {
-                  "line": 233,
+                  "line": 234,
                   "column": 13
                 }
               },
@@ -9940,11 +10117,11 @@
               "description": "The error message to display when the input is invalid.",
               "sourceRange": {
                 "start": {
-                  "line": 238,
+                  "line": 239,
                   "column": 12
                 },
                 "end": {
-                  "line": 240,
+                  "line": 241,
                   "column": 13
                 }
               },
@@ -9956,11 +10133,11 @@
               "description": "",
               "sourceRange": {
                 "start": {
-                  "line": 242,
+                  "line": 243,
                   "column": 12
                 },
                 "end": {
-                  "line": 244,
+                  "line": 245,
                   "column": 13
                 }
               },
@@ -9972,11 +10149,11 @@
               "description": "A placeholder string in addition to the label.",
               "sourceRange": {
                 "start": {
-                  "line": 249,
+                  "line": 250,
                   "column": 12
                 },
                 "end": {
-                  "line": 252,
+                  "line": 253,
                   "column": 13
                 }
               },
@@ -10025,11 +10202,11 @@
               "range": {
                 "file": "src/vaadin-combo-box.html",
                 "start": {
-                  "line": 77,
+                  "line": 78,
                   "column": 6
                 },
                 "end": {
-                  "line": 77,
+                  "line": 78,
                   "column": 47
                 }
               }

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -90,6 +90,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
           opened: Boolean,
 
+          /**
+           * The element to position/align the dropdown by.
+           */
+          positionTarget: {
+            type: Object
+          },
+
           /*
            * `true` when new items are being loaded.
            */

--- a/test/data-binding.html
+++ b/test/data-binding.html
@@ -8,6 +8,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="common.html">
   <script src="common.js"></script>
+  <link rel="import" href="../../iron-input/iron-input.html">
 </head>
 
 <body>

--- a/test/item-template.html
+++ b/test/item-template.html
@@ -30,6 +30,9 @@
       document.addEventListener('WebComponentsReady', () => {
         Polymer({
           is: 'x-scope',
+          properties: {
+            items: Array
+          },
           parentMethod: () => {
             return 'quux';
           },

--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -8,6 +8,7 @@
   <script src='../../web-component-tester/browser.js'></script>
   <link rel='import' href='common.html'>
   <script src="common.js"></script>
+  <link rel="import" href="../../paper-input/paper-input-container.html">
 </head>
 
 <body>
@@ -47,7 +48,7 @@
   <template>
     <x-fixed>
       <paper-input-container>
-        <input>
+        <input slot="input">
       </paper-input-container>
 
       <vaadin-combo-box label='combobox' style='width: 300px'></vaadin-combo-box>

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -8,6 +8,7 @@
   <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="common.html">
   <script src="common.js"></script>
+  <link rel="import" href="../../iron-input/iron-input.html">
 </head>
 
 <body>

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -9,6 +9,7 @@
   <link rel="import" href="../vaadin-combo-box-light.html">
   <link rel="import" href="../../iron-input/iron-input.html">
   <link rel="import" href="../../paper-input/paper-input.html">
+  <link rel="import" href="../../paper-button/paper-button.html">
 </head>
 
 <body>


### PR DESCRIPTION
Fixes #512 

Not including `./test` due to the one remaining warning:
```sh
      <vaadin-combo-box></vaadin-combo-box>
      ~~~~~~~~~~~~~~~~~~

test/late-upgrade.html(15,6) warning [undefined-elements] - The element vaadin-combo-box is not defined
```

This one is intentional so we are not inclined to fix it, and AFAIK there is still no way to opt-out particular rules. Same goes for 58 warnings in the `./demo` directory: our approach is to import all the dependencies used in demos in `index.html`, which does not satisfy linter requirements.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/592)
<!-- Reviewable:end -->
