### PR TITLE
Restore focus-ring if firstly was focused with Tab

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -243,6 +243,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (this.opened) {
+        this._openedWithFocusRing = this.hasAttribute('focus-ring');
         // For touch devices, we don't want to popup virtual keyboard on touch devices unless input
         // is explicitly focused by the user.
         if (!this.$.overlay.touchDevice) {
@@ -251,6 +252,8 @@ This program is available under Apache License Version 2.0, available at https:/
             this.focus();
           }
         }
+      } else if (this._openedWithFocusRing) {
+        this.focusElement.setAttribute('focus-ring', '');
       }
     }
 

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -243,7 +243,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (this.opened) {
-        this._openedWithFocusRing = this.hasAttribute('focus-ring');
+        this._openedWithFocusRing = this.hasAttribute('focus-ring') || (this.focusElement && this.focusElement.hasAttribute('focus-ring'));
         // For touch devices, we don't want to popup virtual keyboard on touch devices unless input
         // is explicitly focused by the user.
         if (!this.$.overlay.touchDevice) {

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -252,7 +252,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.focus();
           }
         }
-      } else if (this._openedWithFocusRing) {
+      } else if (this._openedWithFocusRing && this.hasAttribute('focused')) {
         this.focusElement.setAttribute('focus-ring', '');
       }
     }

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -54,6 +54,13 @@
         expect(combobox.opened).to.be.true;
       });
 
+      it('should restore attribute focus-ring if it was initially set before opening', () => {
+        combobox.setAttribute('focus-ring', '');
+        combobox.opened = true;
+        combobox.opened = false;
+        expect(combobox.focusElement.hasAttribute('focus-ring')).to.be.true;
+      });
+
       it('should open synchronously by clicking input', () => {
         expect(combobox.opened).to.be.false;
         fireMousedownMouseupClick(combobox.inputElement);

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -54,11 +54,11 @@
         expect(combobox.opened).to.be.true;
       });
 
-      it('should restore attribute focus-ring if it was initially set before opening', () => {
+      it('should restore attribute focus-ring if it was initially set before opening and combo-box is focused', () => {
         combobox.setAttribute('focus-ring', '');
         combobox.opened = true;
         combobox.opened = false;
-        expect(combobox.focusElement.hasAttribute('focus-ring')).to.be.true;
+        expect(!combobox.hasAttribute('focused') || combobox.focusElement.hasAttribute('focus-ring')).to.be.true;
       });
 
       it('should open synchronously by clicking input', () => {


### PR DESCRIPTION
Connected to https://github.com/vaadin/components-team-tasks/issues/306

Restore `focus-ring` if component was firstly focused with <kbd>Tab</kbd>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/599)
<!-- Reviewable:end -->
