### PR TITLE
Update Lumo theme

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -34,13 +34,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
             -webkit-overflow-scrolling: touch;
-          }
 
-          #selector {
-            --iron-list-items-container: {
-              border-top: 8px solid transparent;
-              border-bottom: 8px solid transparent;
-            };
+            /* Fixes scrollbar disappearing when "Show scroll bars: Always" enabled in Safari */
+            box-shadow: 0 0 0 white;
           }
         </style>
         <div id="scroller" on-click="_stopPropagation" hidden$="[[loading]]">

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -459,6 +459,7 @@ This program is available under Apache License Version 2.0, available at https:/
       // the items synchonously. It is required to have the items rendered
       // before we update the overlay and the list positions and sizes.
       this.$.overlay.ensureItemsRendered();
+      this.$.overlay._selector.toggleScrollListener(true);
 
       // Ensure metrics are up-to-date
       this.$.overlay.updateViewportBoundaries();

--- a/theme/lumo/vaadin-combo-box-dropdown.html
+++ b/theme/lumo/vaadin-combo-box-dropdown.html
@@ -6,13 +6,17 @@
 <dom-module id="lumo-combo-box-overlay" theme-for="vaadin-combo-box-overlay">
   <template>
     <style include="lumo-menu-overlay">
-      [part="content"] {
-        padding: 0;
+      [part="overlay"] {
+        overflow: hidden;
+        border-radius: var(--lumo-border-radius);
       }
 
-      /* TODO unsupported selector */
-      #scroller {
-        border-radius: var(--lumo-border-radius);
+      [part="content"] {
+        padding: 0;
+        /* TODO using a legacy mixin (unsupported) */
+        --iron-list-items-container: {
+          border: var(--lumo-space-xs) solid transparent;
+        };
       }
     </style>
   </template>

--- a/theme/lumo/vaadin-combo-box-dropdown.html
+++ b/theme/lumo/vaadin-combo-box-dropdown.html
@@ -1,3 +1,4 @@
+<link rel="import" href="../../../vaadin-lumo-styles/spacing.html">
 <link rel="import" href="../../../vaadin-lumo-styles/style.html">
 
 <link rel="import" href="../../../vaadin-overlay/theme/lumo/vaadin-overlay.html">
@@ -13,10 +14,13 @@
 
       [part="content"] {
         padding: 0;
+      }
+
+      iron-list {
         /* TODO using a legacy mixin (unsupported) */
         --iron-list-items-container: {
           border: var(--lumo-space-xs) solid transparent;
-        };
+        }
       }
     </style>
   </template>

--- a/theme/lumo/vaadin-combo-box-item.html
+++ b/theme/lumo/vaadin-combo-box-item.html
@@ -7,60 +7,39 @@
 <dom-module id="lumo-combo-box-item" theme-for="vaadin-combo-box-item">
   <template>
     <style include="lumo-item">
-      /* TODO partly duplicated from lumo-menu-overlay styles. Should find a way to make it DRY */
+      /* TODO partly duplicated from vaadin-list-box styles. Should find a way to make it DRY */
 
       :host {
         cursor: pointer;
-        padding-top: var(--lumo-space-xs);
-        padding-bottom: var(--lumo-space-xs);
-        padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
-        padding-left: calc(var(--lumo-space-xs) + var(--lumo-border-radius) / 4);
         -webkit-tap-highlight-color: var(--lumo-primary-color-10pct);
-        min-height: var(--lumo-size-m);
+        padding-left: calc(var(--lumo-border-radius) / 4);
+        padding-right: calc(var(--lumo-space-l) + var(--lumo-border-radius) / 4);
+        transition: background-color 100ms;
+        border-radius: var(--lumo-border-radius);
+        overflow: hidden;
       }
 
-      /* ShadyCSS workaround */
+      /* ShadyCSS workaround (show the selected item checkmark) */
       :host::before {
         display: block;
       }
 
-      /* Only apply for this particular item, not nested items */
-      :host > * {
-        --_lumo-item-selected-icon-display: none;
-      }
-
-      :host([focused]) {
+      :host(:hover) {
         background-color: var(--lumo-primary-color-10pct);
       }
 
+      :host([focused]:not([disabled])) {
+        box-shadow: inset 0 0 0 2px var(--lumo-primary-color-50pct);
+      }
+
       @media (pointer: coarse) {
-        :host([focused]) {
+        :host(:hover) {
           background-color: transparent;
         }
-      }
 
-      :host([selected]) {
-        font-weight: 500;
-      }
-
-      /* Need to use a bold font on Windows (Segoe UI doesn't have semibold) */
-      ::-ms-backdrop,
-      :host([selected]) {
-        font-weight: 600;
-      }
-
-      @supports (-ms-ime-align: auto) {
-        [part="items"] ::slotted([selected]) {
-          font-weight: 600;
+        :host([focused]:not([disabled])) {
+          box-shadow: none;
         }
-      }
-
-      /* TODO ugly hack to add horizontal spacing between the overlay and the item */
-      /* Should eventually be fixed so that using paddings for the combo box overlay is straightforward */
-      :host {
-        left: var(--lumo-space-xs);
-        right: var(--lumo-space-xs);
-        width: auto !important;
       }
     </style>
   </template>

--- a/theme/lumo/vaadin-combo-box-item.html
+++ b/theme/lumo/vaadin-combo-box-item.html
@@ -17,6 +17,7 @@
         transition: background-color 100ms;
         border-radius: var(--lumo-border-radius);
         overflow: hidden;
+        --_lumo-item-selected-icon-display: block;
       }
 
       /* ShadyCSS workaround (show the selected item checkmark) */


### PR DESCRIPTION
Depend on latest `vaadin-item` theme, and copy latest style changes from `vaadin-list-box` (e.g. separate hover and focus styles for items).

Fix overlay “padding” by using the undocumented (and unsupported) CSS mixin and setting a border on the internal iron-list items container.

Fixes #598 
Fixes #605

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/601)
<!-- Reviewable:end -->
