### PR TITLE
Set tabindex attribute on vaadin-combo-box-item

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -42,8 +42,17 @@ This program is available under Apache License Version 2.0, available at https:/
         <div id="scroller" on-click="_stopPropagation" hidden$="[[loading]]">
           <iron-list id="selector" role="listbox" items="[[_items]]" scroll-target="[[_scroller]]">
             <template>
-              <vaadin-combo-box-item on-click="_onItemClick" index="[[index]]" item="[[item]]" label="[[getItemLabel(item)]]" selected="[[_isItemSelected(item, _selectedItem)]]"
-                role$="[[_getAriaRole(index)]]" aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]" focused="[[_isItemFocused(_focusedIndex,index)]]" touch-device$="[[touchDevice]]">
+              <vaadin-combo-box-item
+                on-click="_onItemClick"
+                index="[[index]]"
+                item="[[item]]"
+                label="[[getItemLabel(item)]]"
+                selected="[[_isItemSelected(item, _selectedItem)]]"
+                role$="[[_getAriaRole(index)]]"
+                aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
+                focused="[[_isItemFocused(_focusedIndex,index)]]"
+                touch-device$="[[touchDevice]]"
+                tabindex="-1">
               </vaadin-combo-box-item>
             </template>
           </iron-list>


### PR DESCRIPTION
The `vaadin-item` Lumo theme depends on `tabindex` attribute here: https://github.com/vaadin/vaadin-item/blob/master/theme/lumo/vaadin-item.html#L23

In the dropdown-menu the attribute is managed by list-mixin but we don't use it here, so we have to set this attribute on combo-box items in markup.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/606)
<!-- Reviewable:end -->
