### PR TITLE
Remove iron-form observer no longer guaranteed to exist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: true
 dist: trusty
 language: node_js
-node_js: 8.0
+node_js: 8.9
 
 cache:
   directories:

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -80,7 +80,6 @@
 
       beforeEach(() => {
         ironForm = fixture('combobox-in-form');
-        ironForm._nodeObserver.flush();
         comboBox = ironForm.querySelector('vaadin-combo-box');
         form = ironForm.querySelector('form');
         comboBox.name = 'foo';


### PR DESCRIPTION
Starting from the `<iron-form>` 2.1.3, the observer is not initialised when the native `<form>` is found, see PolymerElements/iron-form@1b94f7d

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/610)
<!-- Reviewable:end -->
