### PR TITLE
Use refactored lumo-menu-overlay styles

### DIFF
--- a/theme/lumo/vaadin-combo-box-dropdown.html
+++ b/theme/lumo/vaadin-combo-box-dropdown.html
@@ -6,12 +6,7 @@
 
 <dom-module id="lumo-combo-box-overlay" theme-for="vaadin-combo-box-overlay">
   <template>
-    <style include="lumo-menu-overlay">
-      [part="overlay"] {
-        overflow: hidden;
-        border-radius: var(--lumo-border-radius);
-      }
-
+    <style include="lumo-overlay lumo-menu-overlay-core">
       [part="content"] {
         padding: 0;
       }


### PR DESCRIPTION
Depends on https://github.com/vaadin/vaadin-lumo-styles/pull/9

Remove redundant part="overlay" styles at the same time.