### PR TITLE
Fix filteredItems to work properly when configured by default

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -621,7 +621,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       this.$.overlay._selectedItem = selectedItem;
-      if (this.filteredItems) {
+      if (this.filteredItems && this.$.overlay._items) {
         this._focusedIndex = this.filteredItems.indexOf(selectedItem);
       }
     }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -560,7 +560,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // With certain use cases (e. g., external filtering), `items` are
         // undefined. Filtering is unnecessary per se, but the filteredItems
         // observer should still be invoked to update focused item.
-        this._filteredItemsChanged({path: 'filteredItems'}, itemValuePath, itemLabelPath);
+        this._filteredItemsChanged({path: 'filteredItems', value: this.filteredItems}, itemValuePath, itemLabelPath);
       }
     }
 
@@ -660,7 +660,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _itemsChanged(e, itemValuePath, itemLabelPath) {
-      if (e === undefined || itemValuePath === undefined || itemLabelPath === undefined) {
+      if (e.value === undefined || itemValuePath === undefined || itemLabelPath === undefined) {
         return;
       }
       if (e.path === 'items' || e.path === 'items.splices') {
@@ -677,7 +677,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _filteredItemsChanged(e, itemValuePath, itemLabelPath) {
-      if (e === undefined || itemValuePath === undefined || itemLabelPath === undefined) {
+      if (e.value === undefined || itemValuePath === undefined || itemLabelPath === undefined) {
         return;
       }
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -232,8 +232,10 @@
 
     describe('external filtering', () => {
       beforeEach(() => {
-        comboBox.items = undefined;
-        comboBox.filteredItems = ['foo', 'bar', 'baz'];
+        comboBox.setProperties({
+          filteredItems: ['foo', 'bar', 'baz'],
+          items: undefined
+        });
       });
 
       it('should set items to filteredItems', () => {

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -18,6 +18,12 @@
   </template>
 </test-fixture>
 
+<test-fixture id='configured'>
+  <template>
+    <vaadin-combo-box filtered-items='["a", "b", "c"]' value='b'></vaadin-combo-box>
+  </template>
+</test-fixture>
+
 <script>
   describe('filtering items', () => {
     let comboBox;
@@ -331,6 +337,11 @@
         comboBox.loading = false;
         expect(comboBox.hasAttribute('loading')).to.be.false;
         expect(comboBox.$.overlay.$.dropdown.$.overlay.hasAttribute('loading')).to.be.false;
+      });
+
+      it('should not throw when passing filteredItems and value as attributes', () => {
+        comboBox = fixture('configured');
+        expect(comboBox._focusedIndex).to.eql(1);
       });
     });
   });


### PR DESCRIPTION
Fixes #615 

There were 3 problems here:
1. improper guard for multi-property observers
2. improper test setup: setting the `items` to `undefined` before the `filteredItems` allowed the tests to pass so the problem above was not actually covered. Fixed by using `setProperties` to ensure batch observers which revealed 1 broken test on the current master
3. missing check for overlay items causing `_focusedIndex` to be assigned too early

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/628)
<!-- Reviewable:end -->
