### PR TITLE
Fix iron-list mixin not applied for combo-box in dom-if template

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -20,6 +20,7 @@
     "fixture": false,
     "fire": false,
     "fireMousedownMouseupClick": false,
+    "getCustomPropertyValue": false,
     "System": false,
     "HTMLImports": false,
     "MockInteractions": false,

--- a/test/common.js
+++ b/test/common.js
@@ -12,6 +12,12 @@ const touchDevice = (() => {
   }
 })();
 
+const getCustomPropertyValue = (el, prop) => {
+  return window.ShadyCSS ?
+    window.ShadyCSS.getComputedStyleValue(el, prop) :
+    getComputedStyle(el).getPropertyValue(prop);
+};
+
 const fire = (type, node, detail) => {
   const evt = new CustomEvent(type, {detail: detail, bubbles: true, cancelable: true, composed: true});
   node.dispatchEvent(evt);

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -9,6 +9,7 @@
   <link rel="import" href="common.html">
   <script src="common.js"></script>
   <link rel="import" href="../../iron-input/iron-input.html">
+  <link rel="import" href="../../polymer/lib/elements/dom-if.html">
 </head>
 
 <body>
@@ -26,6 +27,18 @@
         <input>
       </iron-input>
     </vaadin-combo-box-light>
+  </template>
+</test-fixture>
+
+<test-fixture id="combobox-if">
+  <template>
+    <div>
+      <dom-if if="">
+        <template>
+          <vaadin-combo-box label="Label" items="[1, 2]"></vaadin-combo-box>
+        </template>
+      </dom-if>
+    </div>
   </template>
 </test-fixture>
 
@@ -131,6 +144,21 @@
           expect(overlay().classList.contains('style-scope')).to.be.false;
           expect(overlay().classList.contains('vaadin-combo-box')).to.be.false;
         }
+      });
+
+      it('should extract the iron-list border mixin into custom CSS properties', () => {
+        const elem = fixture('combobox-if');
+
+        // render dom-if template
+        Polymer.flush();
+
+        combobox = elem.querySelector('vaadin-combo-box');
+        combobox.open();
+
+        const selector = combobox.$.overlay._selector;
+        ['border-width', 'border-style', 'border-color'].forEach(prop => {
+          expect(getCustomPropertyValue(selector, `--iron-list-items-container_-_${prop}`)).to.be.ok;
+        });
       });
 
       describe('after opening', () => {

--- a/theme/lumo/vaadin-combo-box-dropdown.html
+++ b/theme/lumo/vaadin-combo-box-dropdown.html
@@ -16,10 +16,19 @@
         padding: 0;
       }
 
+      /* TODO: workaround ShadyCSS issue when using inside of the dom-if */
+      :host([opened]) {
+        --iron-list-items-container_-_border-width: var(--lumo-space-xs);
+        --iron-list-items-container_-_border-style: solid;
+        --iron-list-items-container_-_border-color: transparent;
+      }
+
       iron-list {
-        /* TODO using a legacy mixin (unsupported) */
+        /* TODO: using a legacy mixin (unsupported) */
         --iron-list-items-container: {
-          border: var(--lumo-space-xs) solid transparent;
+          border-width: var(--lumo-space-xs);
+          border-style: solid;
+          border-color: transparent;
         }
       }
     </style>


### PR DESCRIPTION
Fixes #618 

Introducing another workaround for that makes me sad, but anyways we should get rid of `iron-list` eventually.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/631)
<!-- Reviewable:end -->
