### PR TITLE
Disable animations in tests

### DIFF
--- a/test/common.html
+++ b/test/common.html
@@ -11,4 +11,17 @@
   <link rel="import" href="../vaadin-combo-box-light.html">
 </head>
 
+<dom-module id="not-animated-combo-box-overlay" theme-for="vaadin-combo-box-overlay">
+  <template>
+    <style include="lumo-combo-box-overlay">
+      :host([opening]),
+      :host([closing]),
+      :host([opening]) [part="overlay"],
+      :host([closing]) [part="overlay"] {
+        animation: none !important;
+      }
+    </style>
+  </template>
+</dom-module>
+
 </html>


### PR DESCRIPTION
In the upcoming `vaadin-overlay` release, the animations feature is to be introduced, which in conjunction with the default animation styles in latest Lumo (`lumo-menu-overlay-core`) cause random failures like this:

```
Error: Cannot read property 'insertBefore' of null
  HTMLElement._detachOverlay at /components/vaadin-overlay/src/vaadin-overlay.html:430
        HTMLElement.listener at /components/vaadin-overlay/src/vaadin-overlay.html:417
```

This error especially occurs when calling `combobox.open()` inside of the `beforeEach` hook.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/632)
<!-- Reviewable:end -->
