### PR TITLE
Cleanup incorrect data-binding in test

### DIFF
--- a/test/item-template.html
+++ b/test/item-template.html
@@ -44,7 +44,7 @@
 
   <test-fixture id="scope">
     <template>
-      <x-scope items="[[items]]"></x-scope>
+      <x-scope></x-scope>
     </template>
   </test-fixture>
 


### PR DESCRIPTION
This line is not needed and produces warnings:
```
Polymer::Attributes: couldn't decode Array as JSON: [[items]]
```

The correct binding is already present here: https://github.com/vaadin/vaadin-combo-box/blob/master/test/item-template.html#L16

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/645)
<!-- Reviewable:end -->
