### PR TITLE
In touch devices open keyboard on second click

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -285,7 +285,10 @@ This program is available under Apache License Version 2.0, available at https:/
         if (path.indexOf(this._toggleElement) > -1 && this.opened) {
           this.close();
         } else {
+          // In touch devices we avoid opening soft keyboard until a second touch
+          const blurOnOpen = !this.opened && this.$.overlay.touchDevice;
           this.open();
+          blurOnOpen && this.inputElement.blur();
         }
       }
 


### PR DESCRIPTION
This is a UX change to mitigate problems in touch-devices  when keyboard is opened at the same time than keyboard.
Since in most use cases, user does not need to filter items,  the idea behind this change is that user needs to double touch the input to focus the text-field. 

Connected to #646

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/656)
<!-- Reviewable:end -->
