### PR TITLE
Add basic combo-box demo

### DIFF
--- a/demo/combo-box-basic-demos.html
+++ b/demo/combo-box-basic-demos.html
@@ -6,19 +6,32 @@
       }
     </style>
 
+    <h3>Combo Box</h3>
+
+    <vaadin-demo-snippet id="combo-box-basic-combo-box">
+      <template preserve-content>
+        <vaadin-combo-box id="demo1" label="Element"></vaadin-combo-box>
+        <script>
+          window.addDemoReadyListener('#combo-box-basic-combo-box', function(document) {
+            document.querySelector('#demo1').items = ['Hydrogen', 'Helium', 'Lithium'];
+          });
+        </script>
+      </template>
+    </vaadin-demo-snippet>
+
 
     <h3>Configuring the Combo Box</h3>
 
     <vaadin-demo-snippet id="combo-box-basic-demos-configuring-the-combo-box">
       <template preserve-content>
-        <vaadin-combo-box id="demo1-1" label="Element"></vaadin-combo-box>
-        <vaadin-combo-box id="demo1-2" label="Disabled" disabled></vaadin-combo-box>
-        <vaadin-combo-box id="demo1-3" label="Read-only" value="Carbon" readonly></vaadin-combo-box>
+        <vaadin-combo-box id="demo2-1" label="Element"></vaadin-combo-box>
+        <vaadin-combo-box id="demo2-2" label="Disabled" disabled></vaadin-combo-box>
+        <vaadin-combo-box id="demo2-3" label="Read-only" value="Carbon" readonly></vaadin-combo-box>
         <script>
           window.addDemoReadyListener('#combo-box-basic-demos-configuring-the-combo-box', function(document) {
-            var combobox1 = document.querySelector('#demo1-1');
-            var combobox2 = document.querySelector('#demo1-2');
-            var combobox3 = document.querySelector('#demo1-3');
+            var combobox1 = document.querySelector('#demo2-1');
+            var combobox2 = document.querySelector('#demo2-2');
+            var combobox3 = document.querySelector('#demo2-3');
             combobox1.items = combobox2.items = combobox3.items = elements;
             combobox1.value = combobox2.value = combobox3.value = 'Carbon';
           });
@@ -30,12 +43,12 @@
     <h3>Selecting a Value</h3>
     <vaadin-demo-snippet id="combo-box-basic-demos-selecting-a-value">
       <template preserve-content>
-        <vaadin-combo-box id="demo2" label="Element"></vaadin-combo-box>
+        <vaadin-combo-box id="demo3" label="Element"></vaadin-combo-box>
         <p>Selected value: <span id="selected-value"></span>.</p>
 
         <script>
           window.addDemoReadyListener('#combo-box-basic-demos-selecting-a-value', function(document) {
-            var combobox = document.querySelector('#demo2');
+            var combobox = document.querySelector('#demo3');
             combobox.items = elements;
 
             combobox.addEventListener('value-changed', function() {
@@ -110,12 +123,12 @@
     <p>Allow the user to set any value for the field in addition to selecting a value from the dropdown menu.</p>
     <vaadin-demo-snippet id="combo-box-basic-demos-allow-custom-values">
       <template preserve-content>
-        <vaadin-combo-box id="demo1" label="Element" allow-custom-value></vaadin-combo-box>
+        <vaadin-combo-box id="demo6" label="Element" allow-custom-value></vaadin-combo-box>
         <p>Selected value: <span id="selected-value2"></span></p>
 
         <script>
           window.addDemoReadyListener('#combo-box-basic-demos-allow-custom-values', function(document) {
-            var combobox = document.querySelector('#demo1');
+            var combobox = document.querySelector('#demo6');
             combobox.items = elements;
 
             combobox.addEventListener('value-changed', function() {


### PR DESCRIPTION
Connects to "Guidelines for component examples": Make the first demo support copy-pasting. At the moment the first basic demo is using `elements ` array and if I copy paste it to my own code base, the example will break as `elements` is not defined.

This PR creates a new first demo that the user can copy-paste. Other demos still use `elements` array as I don't think it is good to have new array in every example

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/669)
<!-- Reviewable:end -->
