### PR TITLE
add null handling for item label properties

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -259,6 +259,8 @@ This program is available under Apache License Version 2.0, available at https:/
         let label = item ? this.get(this._itemLabelPath, item) : undefined;
         if (label === undefined) {
           label = item ? item.toString() : '';
+        } else if (label === null) {
+          label = '';
         }
         return label;
       }

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -257,10 +257,8 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       getItemLabel(item) {
         let label = item ? this.get(this._itemLabelPath, item) : undefined;
-        if (label === undefined) {
+        if (label === undefined || label === null) {
           label = item ? item.toString() : '';
-        } else if (label === null) {
-          label = '';
         }
         return label;
       }

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -133,15 +133,16 @@
         expect(combobox.value).to.eql('default');
       });
 
-      it('should handle null value for the provided label property', () => {
+      it('should use toString if provided label property is null', () => {
         combobox.items = [{
           custom: null
         }];
+        combobox.items[0].toString = () => 'default';
         combobox.itemLabelPath = 'custom';
 
         selectItem(0);
 
-        expect(combobox.inputElement.value).to.eql('');
+        expect(combobox.inputElement.value).to.eql('default');
       });
 
       it('should set the selected item when open', () => {

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -133,6 +133,17 @@
         expect(combobox.value).to.eql('default');
       });
 
+      it('should handle null value for the provided label property', () => {
+        combobox.items = [{
+          custom: null
+        }];
+        combobox.itemLabelPath = 'custom';
+
+        selectItem(0);
+
+        expect(combobox.inputElement.value).to.eql('');
+      });
+
       it('should set the selected item when open', () => {
         combobox.value = 'bar';
 


### PR DESCRIPTION
This PR fixes the issue (#680) of the `vaadin-combo-box` failing to render when an item property used as a label path has a `null` value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/681)
<!-- Reviewable:end -->
