### PR TITLE
Avoid notifyResize calls when overlay is closed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
           wct --env saucelabs;
         fi;
       else
-        wct;
+        xvfb-run -s '-screen 0 1024x768x24' wct;
       fi &&
       if [[ "$TRAVIS_EVENT_TYPE" = "cron" && "$TEST_SUITE" = "unit_tests" ]]; then
         wct --env saucelabs-cron;
@@ -59,7 +59,7 @@ script:
       if [[ "$TRAVIS_EVENT_TYPE" != "pull_request" && "$TRAVIS_BRANCH" != quick/* ]]; then
         wct --npm --env saucelabs;
       else
-        wct --npm;
+        xvfb-run -s '-screen 0 1024x768x24' wct --npm;
       fi;
     fi
 

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -190,7 +190,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _setOverlayHeight() {
-        if (!this.positionTarget || !this._selector) {
+        if (!this.opened || !this.positionTarget || !this._selector) {
           return;
         }
 

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -484,7 +484,7 @@ This program is available under Apache License Version 2.0, available at https:/
       // Ensure metrics are up-to-date
       this.$.overlay.updateViewportBoundaries();
       Polymer.Async.microTask.run(() => this.$.overlay.adjustScrollPosition());
-      setTimeout(() => this.$.overlay.$.dropdown.notifyResize(), 1);
+      setTimeout(() => this._resizeDropdown(), 1);
 
 
       // _detectAndDispatchChange() should not consider value changes done before opening
@@ -595,6 +595,10 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    _resizeDropdown() {
+      this.$.overlay.$.dropdown.notifyResize();
+    }
+
     _updateHasValue(hasValue) {
       if (hasValue) {
         this.setAttribute('has-value', '');
@@ -695,15 +699,9 @@ This program is available under Apache License Version 2.0, available at https:/
           this.$.overlay.indexOfLabel(this.filter) :
           this._indexOfValue(this.value, this.filteredItems);
 
-        // async needed to reposition correctly after filtering
-        // (especially when aligned on top of input)
-        setTimeout(() => {
-          this.$.overlay.$.dropdown.notifyResize();
-          this.$.overlay.updateViewportBoundaries();
-          this.$.overlay.ensureItemsRendered();
-          this.$.overlay._selector.notifyResize();
-          Polymer.flush && Polymer.flush();
-        }, 1);
+        if (this.opened) {
+          this._repositionOverlay();
+        }
       }
     }
 
@@ -722,7 +720,21 @@ This program is available under Apache License Version 2.0, available at https:/
     _setOverlayItems(items) {
       this.$.overlay.set('_items', items);
 
-      this.$.overlay.$.dropdown.notifyResize();
+      if (this.opened) {
+        this._resizeDropdown();
+      }
+    }
+
+    _repositionOverlay() {
+      // async needed to reposition correctly after filtering
+      // (especially when aligned on top of input)
+      setTimeout(() => {
+        this._resizeDropdown();
+        this.$.overlay.updateViewportBoundaries();
+        this.$.overlay.ensureItemsRendered();
+        this.$.overlay._selector.notifyResize();
+        Polymer.flush && Polymer.flush();
+      }, 1);
     }
 
     _indexOfValue(value, items) {

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -345,6 +345,27 @@
         comboBox = fixture('configured');
         expect(comboBox._focusedIndex).to.eql(1);
       });
+
+      it('should not notify resize the dropdown if not opened', () => {
+        const resizeSpy = sinon.spy(comboBox.$.overlay.$.dropdown, 'notifyResize');
+        comboBox.filteredItems = ['foo', 'bar', 'baz'];
+
+        expect(resizeSpy).to.not.have.been.called;
+      });
+
+      it('should not re-position the overlay if not opened', () => {
+        const repositionSpy = sinon.spy(comboBox, '_repositionOverlay');
+        comboBox.filteredItems = ['foo', 'bar', 'baz'];
+
+        expect(repositionSpy).to.not.have.been.called;
+      });
+
+      it('should not perform measurements when loading changes if not opened', () => {
+        const measureSpy = sinon.spy(comboBox.inputElement, 'getBoundingClientRect');
+        comboBox.loading = true;
+
+        expect(measureSpy).to.not.have.been.called;
+      });
     });
 
     describe('setting items when opened', () => {

--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -141,10 +141,18 @@
       });
 
       it('should notify resize on items change', () => {
+        comboBox.opened = true;
         const spy = sinon.spy();
         comboBox.$.overlay.$.dropdown.notifyResize = spy;
         comboBox.items = [1, 2, 3];
         expect(spy.called).to.be.true;
+      });
+
+      it('should not notify resize when not opened', () => {
+        const spy = sinon.spy();
+        comboBox.$.overlay.$.dropdown.notifyResize = spy;
+        comboBox.items = [1, 2, 3];
+        expect(spy.called).to.be.false;
       });
 
       it('should reposition on scroll', () => {

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -11,9 +11,6 @@ module.exports = {
           'headless',
           'disable-gpu',
           'no-sandbox'
-        ],
-        firefox: [
-          '-headless'
         ]
       }
     },


### PR DESCRIPTION
Fixes #694 

### Before

![screen shot 2018-08-13 at 15 35 58](https://user-images.githubusercontent.com/10589913/44075378-46b3e1f4-9fa5-11e8-9634-42b564a03e4a.png)

notice lot of red points, these are perf bottlenecks caused by reflow due to resize notifications and also `getBoundingClientRect()` measurements which are not needed at this point.

time to render on my machine - above 12 ms per instance

### After

![screen shot 2018-08-14 at 9 40 59](https://user-images.githubusercontent.com/10589913/44075643-373c0ec6-9fa6-11e8-8dbf-7c8cea965712.png)

time to render on my machine - 8 ms per instance

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/700)
<!-- Reviewable:end -->
