### PR TITLE
Cleanup unused code and unnecessary DOM measurements

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -5,9 +5,7 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../polymer/lib/utils/debounce.html">
 <link rel="import" href="../../iron-list/iron-list.html">
-<link rel="import" href="../../iron-resizable-behavior/iron-resizable-behavior.html">
 <link rel="import" href="vaadin-combo-box-item.html">
 <link rel="import" href="vaadin-combo-box-dropdown.html">
 

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -46,7 +46,6 @@ This program is available under Apache License Version 2.0, available at https:/
                 role$="[[_getAriaRole(index)]]"
                 aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
                 focused="[[_isItemFocused(_focusedIndex,index)]]"
-                touch-device$="[[touchDevice]]"
                 tabindex="-1">
               </vaadin-combo-box-item>
             </template>
@@ -59,6 +58,17 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <script>
   (function() {
+    'use strict';
+
+    const TOUCH_DEVICE = (() => {
+      try {
+        document.createEvent('TouchEvent');
+        return true;
+      } catch (e) {
+        return false;
+      }
+    })();
+
     /**
      * Element for internal use only.
      *
@@ -77,15 +87,7 @@ This program is available under Apache License Version 2.0, available at https:/
            */
           touchDevice: {
             type: Boolean,
-            reflectToAttribute: true,
-            value: () => {
-              try {
-                document.createEvent('TouchEvent');
-                return true;
-              } catch (e) {
-                return false;
-              }
-            }
+            value: TOUCH_DEVICE
           },
 
           opened: Boolean,

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -122,7 +122,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
           _focusedIndex: {
             type: Number,
-            notify: true,
             value: -1,
             observer: '_focusedIndexChanged'
           },
@@ -206,11 +205,13 @@ This program is available under Apache License Version 2.0, available at https:/
           window.ShadyCSS.getComputedStyleValue(this, '--vaadin-combo-box-overlay-max-height') :
           getComputedStyle(this).getPropertyValue('--vaadin-combo-box-overlay-max-height')) || '65vh';
 
+        const maxHeight = this._maxOverlayHeight(targetRect);
+
         // overlay max height is restrained by the #scroller max height which is set to 65vh in CSS.
-        this.$.dropdown.$.overlay.style.maxHeight = this._maxOverlayHeight(targetRect);
+        this.$.dropdown.$.overlay.style.maxHeight = maxHeight;
 
         // we need to set height for iron-list to make its `firstVisibleIndex` work correctly.
-        this._selector.style.maxHeight = this._maxOverlayHeight(targetRect);
+        this._selector.style.maxHeight = maxHeight;
 
         this.updateViewportBoundaries();
       }

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -205,10 +205,10 @@ This program is available under Apache License Version 2.0, available at https:/
         return this.alignedAbove ? -overlayRect.height : targetRect.height;
       }
 
-      _shouldAlignAbove() {
+      _shouldAlignAbove(targetRect) {
         const spaceBelow = (
           window.innerHeight -
-          this.positionTarget.getBoundingClientRect().bottom -
+          targetRect.bottom -
           Math.min(document.body.scrollTop, 0)
         ) / window.innerHeight;
 
@@ -225,7 +225,7 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         const targetRect = this.positionTarget.getBoundingClientRect();
-        this.alignedAbove = this._shouldAlignAbove();
+        this.alignedAbove = this._shouldAlignAbove(targetRect);
 
         const overlayRect = this.$.overlay.getBoundingClientRect();
         this._translateX = targetRect.left - overlayRect.left + (this._translateX || 0);

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -69,22 +69,6 @@ This program is available under Apache License Version 2.0, available at https:/
           },
 
           /**
-           * True if the device supports touch events.
-           */
-          touchDevice: {
-            type: Boolean,
-            reflectToAttribute: true,
-            value: () => {
-              try {
-                document.createEvent('TouchEvent');
-                return true;
-              } catch (e) {
-                return false;
-              }
-            }
-          },
-
-          /**
            * The element to position/align the dropdown by.
            */
           positionTarget: {

--- a/src/vaadin-combo-box-light.html
+++ b/src/vaadin-combo-box-light.html
@@ -100,6 +100,11 @@ This program is available under Apache License Version 2.0, available at https:/
         };
       }
 
+      constructor() {
+        super();
+        this._boundInputValueChanged = this._inputValueChanged.bind(this);
+      }
+
       ready() {
         super.ready();
         this._toggleElement = this.querySelector('.toggle-button');
@@ -115,13 +120,13 @@ This program is available under Apache License Version 2.0, available at https:/
         const cssSelector = 'vaadin-text-field,iron-input,paper-input,.paper-input-input,.input';
         this._setInputElement(this.querySelector(cssSelector));
         this._revertInputValue();
-        this.listen(this.inputElement, 'input', '_inputValueChanged');
+        this.inputElement.addEventListener('input', this._boundInputValueChanged);
         this._preventInputBlur();
       }
 
       disconnectedCallback() {
         super.disconnectedCallback();
-        this.unlisten(this.inputElement, 'input', '_inputValueChanged');
+        this.inputElement.removeEventListener('input', this._boundInputValueChanged);
         this._restoreInputBlur();
       }
 

--- a/src/vaadin-combo-box-light.html
+++ b/src/vaadin-combo-box-light.html
@@ -5,7 +5,6 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="vaadin-combo-box-mixin.html">
 <link rel="import" href="vaadin-combo-box-dropdown-wrapper.html">
@@ -74,9 +73,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * @mixes Vaadin.ComboBoxMixin
      * @mixes Vaadin.ThemableMixin
      */
-    class ComboBoxLightElement extends Vaadin.ThemableMixin(Vaadin.ComboBoxMixin(Polymer.mixinBehaviors(
-      [Polymer.IronA11yKeysBehavior], Polymer.Element
-    ))) {
+    class ComboBoxLightElement extends Vaadin.ThemableMixin(Vaadin.ComboBoxMixin(Polymer.Element)) {
 
       static get is() {
         return 'vaadin-combo-box-light';

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -4,9 +4,11 @@ Copyright (c) 2017 Vaadin Ltd.
 This program is available under Apache License Version 2.0, available at https://vaadin.com/license/
 -->
 
-<link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/utils/async.html">
+<link rel="import" href="../../polymer/lib/utils/flush.html">
 <link rel="import" href="../../polymer/lib/utils/templatize.html">
 <link rel="import" href="../../iron-a11y-announcer/iron-a11y-announcer.html">
+<link rel="import" href="../../iron-a11y-keys-behavior/iron-a11y-keys-behavior.html">
 <link rel="import" href="../../polymer/lib/utils/flattened-nodes-observer.html">
 
 <script>
@@ -518,7 +520,7 @@ This program is available under Apache License Version 2.0, available at https:/
       // Pre P2 iron-list used a debouncer to render. Now that we synchronously render items,
       // we need to flush the DOM to make sure it doesn't get flushed in the middle of _render call
       // because that will cause problems to say the least.
-      Polymer.flush && Polymer.flush();
+      Polymer.flush();
 
       // With iron-list v1.3.9, calling `notifyResize()` no longer renders
       // the items synchronously. It is required to have the items rendered
@@ -778,7 +780,7 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.overlay.updateViewportBoundaries();
         this.$.overlay.ensureItemsRendered();
         this.$.overlay._selector.notifyResize();
-        Polymer.flush && Polymer.flush();
+        Polymer.flush();
       }, 1);
     }
 

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -5,7 +5,6 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
-<link rel="import" href="../../iron-a11y-announcer/iron-a11y-announcer.html">
 <link rel="import" href="../../vaadin-text-field/src/vaadin-text-field.html">
 <link rel="import" href="../../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">


### PR DESCRIPTION
Note: there are two changes which could be _potentially_ breaking:

- removal of `touch-device` attribute from `vaadin-combo-box-item` - __but__ we don't use it anymore, instead CSS media queries ` @media (pointer: coarse) ` are used both in Lumo and Material
- removal of `IronA11yKeysBehavior` from `vaadin-combo-box-light` - __but__ it is not used by component itself, neither by `vaadin-time-picker`, and anyone who wants to extending it can still use `Polymer.mixinBehaviors` himself.

Furthermore, both are not documented parts of the public API, e. g. `touch-device` attribute is not documented anywhere. So, we can consider removing those safely in minor release.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/705)
<!-- Reviewable:end -->
