### PR TITLE
Fix readonly state's a11y

### DIFF
--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -292,7 +292,8 @@ This program is available under Apache License Version 2.0, available at https:/
              */
             disabled: {
               type: Boolean,
-              value: false
+              value: false,
+              observer: '_disabledChanged'
             },
 
             /**
@@ -330,7 +331,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
             readonly: {
               type: Boolean,
-              value: false
+              value: false,
+              observer: '_readonlyChanged'
             },
 
             /**
@@ -381,9 +383,9 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }, true);
 
-          this._nativeInput.setAttribute('role', 'combobox');
-          this._nativeInput.setAttribute('aria-autocomplete', 'list');
+          this.setAttribute('role', 'combobox');
           this._updateAriaExpanded();
+          this._updateNativeInputAriaAutoComplete();
         }
 
         connectedCallback() {
@@ -401,10 +403,24 @@ This program is available under Apache License Version 2.0, available at https:/
         }
 
         _updateAriaExpanded() {
+          this.setAttribute('aria-expanded', this.opened);
+        }
+
+        _updateNativeInputAriaAutoComplete() {
           if (this._nativeInput) {
-            this._nativeInput.setAttribute('aria-expanded', this.opened);
-            this._toggleElement.setAttribute('aria-expanded', this.opened);
+            this.readonly || this.disabled ?
+              this._nativeInput.setAttribute('aria-autocomplete', 'none') :
+              this._nativeInput.setAttribute('aria-autocomplete', 'list');
           }
+        }
+
+        _readonlyChanged() {
+          this._updateAriaExpanded();
+          this._updateNativeInputAriaAutoComplete();
+        }
+
+        _disabledChanged() {
+          this._updateNativeInputAriaAutoComplete();
         }
 
         get inputElement() {

--- a/test/aria.html
+++ b/test/aria.html
@@ -54,12 +54,28 @@
     afterEach(() => comboBox.opened = false);
 
     describe('when combo-box is attached', () => {
-      it('should contain appropriate aria attributes', () => {
-        expect(getNativeInput().getAttribute('role')).to.equal('combobox');
-        expect(getNativeInput().getAttribute('aria-autocomplete')).to.equal('list');
+      const assertAriaAttributes = () => {
         expect(getNativeInput().hasAttribute('aria-labelledby')).to.be.true;
         expect(getToggleIcon().getAttribute('role')).to.equal('button');
         expect(getToggleIcon().getAttribute('aria-label')).to.equal('Toggle');
+        expect(comboBox.getAttribute('role')).to.equal('combobox');
+      };
+
+      it('should contain appropriate aria attributes', () => {
+        expect(getNativeInput().getAttribute('aria-autocomplete')).to.equal('list');
+        assertAriaAttributes();
+      });
+
+      it('should contain appropriate aria attributes for readonly input', () => {
+        comboBox.readonly = true;
+        expect(getNativeInput().getAttribute('aria-autocomplete')).to.equal('none');
+        assertAriaAttributes();
+      });
+
+      it('should contain appropriate aria attributes for disabled input', () => {
+        comboBox.disabled = true;
+        expect(getNativeInput().getAttribute('aria-autocomplete')).to.equal('none');
+        assertAriaAttributes();
       });
     });
 
@@ -72,15 +88,13 @@
       });
 
       it('should set aria-expanded attribute when opened', () => {
-        expect(getNativeInput().getAttribute('aria-expanded')).to.equal('true');
-        expect(getToggleIcon().getAttribute('aria-expanded')).to.equal('true');
+        expect(comboBox.getAttribute('aria-expanded')).to.equal('true');
       });
 
       it('should unset aria-expanded attribute when closed', () => {
         esc();
 
-        expect(getNativeInput().getAttribute('aria-expanded')).to.equal('false');
-        expect(getToggleIcon().getAttribute('aria-expanded')).to.equal('false');
+        expect(comboBox.getAttribute('aria-expanded')).to.equal('false');
       });
     });
 


### PR DESCRIPTION
Readonly input should not have role combobox or aria-expanded (true or false) attribute

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/730)
<!-- Reviewable:end -->
