### PR TITLE
Clear pending requests on clearCache

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -164,6 +164,7 @@ This program is available under Apache License Version 2.0, available at https:/
       if (!this.dataProvider) {
         return;
       }
+      this._pendingRequests = {};
       const filteredItems = [];
       filteredItems.length = this.size || 0;
       this.filteredItems = new Array(...filteredItems).map(item => {

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -614,6 +614,18 @@
               const params = spyDataProvider.firstCall.args[0];
               expect(params.page).to.equal(0);
             });
+
+            it('should clear old pending requests', () => {
+              let slowCallback;
+              comboBox.dataProvider = (params, callback) => {
+                if (!slowCallback) {
+                  slowCallback = callback;
+                }
+              };
+              comboBox.clearCache();
+              slowCallback([{}]);
+              expect(comboBox.filteredItems).to.be.empty;
+            });
           });
 
           describe('after closed', () => {


### PR DESCRIPTION
This PR fixes an issue where old item callbacks populate the combo box filtered items even when `clearCache()` has been invoked

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/733)
<!-- Reviewable:end -->
