### PR TITLE
Reuse the same placeholder instance

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -54,6 +54,10 @@ This program is available under Apache License Version 2.0, available at https:/
           value: () => {
             return {};
           }
+        },
+
+        __placeHolder: {
+          value: new Vaadin.ComboBoxPlaceholder()
         }
 
       };
@@ -167,7 +171,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._pendingRequests = {};
       const filteredItems = [];
       for (let i = 0; i < (this.size || 0); i++) {
-        filteredItems.push(new Vaadin.ComboBoxPlaceholder());
+        filteredItems.push(this.__placeHolder);
       }
       this.filteredItems = filteredItems;
       if (this.opened) {
@@ -178,7 +182,7 @@ This program is available under Apache License Version 2.0, available at https:/
     _sizeChanged(size = 0) {
       const filteredItems = (this.filteredItems || []).slice(0);
       for (let i = 0; i < size; i++) {
-        filteredItems[i] = filteredItems[i] !== undefined ? filteredItems[i] : new Vaadin.ComboBoxPlaceholder();
+        filteredItems[i] = filteredItems[i] !== undefined ? filteredItems[i] : this.__placeHolder;
       }
       this.filteredItems = filteredItems;
     }

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -636,6 +636,13 @@
               });
             });
 
+            it('should reuse one placeholder instance', () => {
+              comboBox.dataProvider = spyAsyncDataProvider;
+              comboBox.size = SIZE;
+              comboBox.clearCache();
+              expect(comboBox.filteredItems[0]).to.equal(comboBox.filteredItems[1]);
+            });
+
             it('should request first page', () => {
               comboBox.dataProvider = spyDataProvider;
               spyDataProvider.reset();


### PR DESCRIPTION
The current master creates new placeholder instances for every unloaded item in the `filteredItems` array when a `dataProvider` is used. Optimize memory use by re-using the same placeholder instance for each pending item.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/744)
<!-- Reviewable:end -->
