### PR TITLE
Postpone overlay stamping to first opening

### DIFF
--- a/demo/combo-box-basic-demos.html
+++ b/demo/combo-box-basic-demos.html
@@ -7,20 +7,42 @@
     </style>
 
     <h3>Combo Box</h3>
+    <script>
+      window.addCombo = function() {
+        const combo = document.createElement('vaadin-combo-box');
+        // combo.hidden=true;
+        
+        const template = document.createElement('template');
+        
+        template.innerHTML = '<div>[[item]]</div>'
+        combo.items = [...Array(100).keys()].map(i => '' + i*2);
+        combo.appendChild(template);
+        document.body.appendChild(combo);
+        
+      }
+    </script>
 
     <vaadin-demo-snippet id="combo-box-basic-combo-box">
       <template preserve-content>
-        <vaadin-combo-box label="Element"></vaadin-combo-box>
+        <!-- <vaadin-combo-box label="Element"></vaadin-combo-box> -->
+        <div id="container"></div>
+        <button>add</button>
+        <input type="number" value="1">
         <script>
           window.addDemoReadyListener('#combo-box-basic-combo-box', function(document) {
-            document.querySelector('vaadin-combo-box').items = ['Hydrogen', 'Helium', 'Lithium'];
+            document.querySelector('button').addEventListener('click', e => {
+                const count = parseInt(document.querySelector('input').value);
+                [...Array(count).keys()].forEach(i => {
+                  addCombo();
+                });
+            })
           });
         </script>
       </template>
     </vaadin-demo-snippet>
 
 
-    <h3>Configuring the Combo Box</h3>
+    <!-- <h3>Configuring the Combo Box</h3>
 
     <vaadin-demo-snippet id="combo-box-basic-demos-configuring-the-combo-box">
       <template preserve-content>
@@ -106,7 +128,7 @@
           });
         </script>
       </template>
-    </vaadin-demo-snippet>
+    </vaadin-demo-snippet> -->
 
   </template>
   <script>

--- a/demo/combo-box-basic-demos.html
+++ b/demo/combo-box-basic-demos.html
@@ -7,42 +7,20 @@
     </style>
 
     <h3>Combo Box</h3>
-    <script>
-      window.addCombo = function() {
-        const combo = document.createElement('vaadin-combo-box');
-        // combo.hidden=true;
-        
-        const template = document.createElement('template');
-        
-        template.innerHTML = '<div>[[item]]</div>'
-        combo.items = [...Array(100).keys()].map(i => '' + i*2);
-        combo.appendChild(template);
-        document.body.appendChild(combo);
-        
-      }
-    </script>
 
     <vaadin-demo-snippet id="combo-box-basic-combo-box">
       <template preserve-content>
-        <!-- <vaadin-combo-box label="Element"></vaadin-combo-box> -->
-        <div id="container"></div>
-        <button>add</button>
-        <input type="number" value="1">
+        <vaadin-combo-box label="Element"></vaadin-combo-box>
         <script>
           window.addDemoReadyListener('#combo-box-basic-combo-box', function(document) {
-            document.querySelector('button').addEventListener('click', e => {
-                const count = parseInt(document.querySelector('input').value);
-                [...Array(count).keys()].forEach(i => {
-                  addCombo();
-                });
-            })
+            document.querySelector('vaadin-combo-box').items = ['Hydrogen', 'Helium', 'Lithium'];
           });
         </script>
       </template>
     </vaadin-demo-snippet>
 
 
-    <!-- <h3>Configuring the Combo Box</h3>
+    <h3>Configuring the Combo Box</h3>
 
     <vaadin-demo-snippet id="combo-box-basic-demos-configuring-the-combo-box">
       <template preserve-content>
@@ -128,7 +106,7 @@
           });
         </script>
       </template>
-    </vaadin-demo-snippet> -->
+    </vaadin-demo-snippet>
 
   </template>
   <script>

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -27,7 +27,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     </style>
 
-    <template is="dom-if" if="[[_firstOpened]]">
+    <template id="dropdown-template" is="dom-if" if="[[_renderDropdown]]">
       <vaadin-combo-box-dropdown id="dropdown"
           hidden="[[_hidden(_items.*, loading)]]"
           position-target="[[positionTarget]]"
@@ -173,12 +173,13 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _openedChanged(opened, items, loading) {
-        if (!this._firstOpened) {
+        if (!this.$.dropdown) {
           if (opened) {
-            this._firstOpened = true;
             this._initDropdown();
           }
-          else return;
+          else {
+            return;
+          }
         }
         // Do not attach if no items
         // Do not dettach if opened but user types an invalid search
@@ -196,14 +197,20 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _initDropdown() {
+        this._renderDropdown = true;
+        this.shadowRoot.querySelector('#dropdown-template').render();
 
-        // this.$.dropdown.opened = !!(this.opened && (this.loading || this.$.dropdown.opened || this._items && this._items.length));
+        this.$.dropdown = this.shadowRoot.querySelector('#dropdown');
+        this.$.dropdown.$.overlay = this.$.dropdown.shadowRoot.querySelector('#overlay');
+
+        this._templateChanged();
+        this._loadingChanged(this.loading);
 
         this.$.dropdown.$.overlay.addEventListener('touchend', e => this._fireTouchAction(e));
         this.$.dropdown.$.overlay.addEventListener('touchmove', e => this._fireTouchAction(e));
- 
-         // Prevent blurring the input when clicking inside the overlay.
-         this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault())
+
+        // Prevent blurring the input when clicking inside the overlay.
+        this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault());
       }
 
       _templateChanged(e) {

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -174,11 +174,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
       _openedChanged(opened, items, loading) {
         if (!this.$.dropdown) {
-          if (opened) {
-            this._initDropdown();
-          }
-          else {
+          if (!opened) {
             return;
+          } else {
+            this._initDropdown();
           }
         }
         // Do not attach if no items

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -12,6 +12,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <dom-module id="vaadin-combo-box-dropdown-wrapper">
   <template>
+    <!-- Stamping the content is postponed until the combo box is opened for the first time -->
     <template id="dropdown-template" is="dom-if" if="[[_renderDropdown]]">
       <style>
         #scroller {

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -191,7 +191,6 @@ This program is available under Apache License Version 2.0, available at https:/
         template.render();
 
         this.$.dropdown = this.shadowRoot.querySelector('#dropdown');
-        this.$.dropdown.$.overlay = this.$.dropdown.shadowRoot.querySelector('#overlay');
 
         this._templateChanged();
         this._loadingChanged(this.loading);

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -26,34 +26,37 @@ This program is available under Apache License Version 2.0, available at https:/
         box-shadow: 0 0 0 white;
       }
     </style>
-    <vaadin-combo-box-dropdown id="dropdown"
-        hidden="[[_hidden(_items.*, loading)]]"
-        position-target="[[positionTarget]]"
-        on-template-changed="_templateChanged"
-        on-position-changed="_setOverlayHeight"
-        theme="[[theme]]">
-      <template>
-        <div id="scroller" on-click="_stopPropagation">
-          <iron-list id="selector" role="listbox" items="[[_getItems(opened, _items)]]" scroll-target="[[_scroller]]">
-            <template>
-              <vaadin-combo-box-item
-                on-click="_onItemClick"
-                index="[[__requestItemByIndex(item, index)]]"
-                item="[[item]]"
-                label="[[getItemLabel(item)]]"
-                selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"
-                renderer="[[renderer]]"
-                role$="[[_getAriaRole(index)]]"
-                aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
-                focused="[[_isItemFocused(_focusedIndex,index)]]"
-                tabindex="-1"
-                theme$="[[theme]]">
-              </vaadin-combo-box-item>
-            </template>
-          </iron-list>
-        </div>
-      </template>
-    </vaadin-combo-box-dropdown>
+
+    <template is="dom-if" if="[[_firstOpened]]">
+      <vaadin-combo-box-dropdown id="dropdown"
+          hidden="[[_hidden(_items.*, loading)]]"
+          position-target="[[positionTarget]]"
+          on-template-changed="_templateChanged"
+          on-position-changed="_setOverlayHeight"
+          theme="[[theme]]">
+        <template>
+          <div id="scroller" on-click="_stopPropagation">
+            <iron-list id="selector" role="listbox" items="[[_getItems(opened, _items)]]" scroll-target="[[_scroller]]">
+              <template>
+                <vaadin-combo-box-item
+                  on-click="_onItemClick"
+                  index="[[__requestItemByIndex(item, index)]]"
+                  item="[[item]]"
+                  label="[[getItemLabel(item)]]"
+                  selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"
+                  renderer="[[renderer]]"
+                  role$="[[_getAriaRole(index)]]"
+                  aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
+                  focused="[[_isItemFocused(_focusedIndex,index)]]"
+                  tabindex="-1"
+                  theme$="[[theme]]">
+                </vaadin-combo-box-item>
+              </template>
+            </iron-list>
+          </div>
+        </template>
+      </vaadin-combo-box-dropdown>
+    </template>
   </template>
 </dom-module>
 
@@ -170,6 +173,13 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _openedChanged(opened, items, loading) {
+        if (!this._firstOpened) {
+          if (opened) {
+            this._firstOpened = true;
+            this._initDropdown();
+          }
+          else return;
+        }
         // Do not attach if no items
         // Do not dettach if opened but user types an invalid search
         this.$.dropdown.opened = !!(opened && (loading || this.$.dropdown.opened || items && items.length));
@@ -183,20 +193,27 @@ This program is available under Apache License Version 2.0, available at https:/
         if (/Trident/.test(navigator.userAgent)) {
           this._scroller.setAttribute('unselectable', 'on');
         }
+      }
+
+      _initDropdown() {
+
+        // this.$.dropdown.opened = !!(this.opened && (this.loading || this.$.dropdown.opened || this._items && this._items.length));
 
         this.$.dropdown.$.overlay.addEventListener('touchend', e => this._fireTouchAction(e));
         this.$.dropdown.$.overlay.addEventListener('touchmove', e => this._fireTouchAction(e));
-
-        // Prevent blurring the input when clicking inside the overlay.
-        this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault());
+ 
+         // Prevent blurring the input when clicking inside the overlay.
+         this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault())
       }
 
       _templateChanged(e) {
+        if (!this.$.dropdown) return;
         this._selector = this.$.dropdown.$.overlay.content.querySelector('#selector');
         this._scroller = this.$.dropdown.$.overlay.content.querySelector('#scroller');
       }
 
       _loadingChanged(loading) {
+        if (!this.$.dropdown) return;
         if (loading) {
           this.$.dropdown.$.overlay.setAttribute('loading', '');
         } else {

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -211,13 +211,19 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _templateChanged(e) {
-        if (!this.$.dropdown) return;
+        if (!this.$.dropdown) {
+          return;
+        }
+
         this._selector = this.$.dropdown.$.overlay.content.querySelector('#selector');
         this._scroller = this.$.dropdown.$.overlay.content.querySelector('#scroller');
       }
 
       _loadingChanged(loading) {
-        if (!this.$.dropdown) return;
+        if (!this.$.dropdown) {
+          return;
+        }
+
         if (loading) {
           this.$.dropdown.$.overlay.setAttribute('loading', '');
         } else {

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -14,20 +14,6 @@ This program is available under Apache License Version 2.0, available at https:/
   <template>
     <!-- Stamping the content is postponed until the combo box is opened for the first time -->
     <template id="dropdown-template" is="dom-if">
-      <style>
-        #scroller {
-          overflow: auto;
-
-          /* Fixes item background from getting on top of scrollbars on Safari */
-          transform: translate3d(0, 0, 0);
-
-          /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
-          -webkit-overflow-scrolling: touch;
-
-          /* Fixes scrollbar disappearing when "Show scroll bars: Always" enabled in Safari */
-          box-shadow: 0 0 0 white;
-        }
-      </style>
       <vaadin-combo-box-dropdown id="dropdown"
           hidden="[[_hidden(_items.*, loading)]]"
           position-target="[[positionTarget]]"
@@ -35,6 +21,20 @@ This program is available under Apache License Version 2.0, available at https:/
           on-position-changed="_setOverlayHeight"
           theme="[[theme]]">
         <template>
+          <style>
+            #scroller {
+              overflow: auto;
+
+              /* Fixes item background from getting on top of scrollbars on Safari */
+              transform: translate3d(0, 0, 0);
+
+              /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
+              -webkit-overflow-scrolling: touch;
+
+              /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
+              box-shadow: 0 0 0 white;
+            }
+          </style>
           <div id="scroller" on-click="_stopPropagation">
             <iron-list id="selector" role="listbox" items="[[_getItems(opened, _items)]]" scroll-target="[[_scroller]]">
               <template>

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -12,22 +12,21 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <dom-module id="vaadin-combo-box-dropdown-wrapper">
   <template>
-    <style>
-      #scroller {
-        overflow: auto;
-
-        /* Fixes item background from getting on top of scrollbars on Safari */
-        transform: translate3d(0, 0, 0);
-
-        /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
-        -webkit-overflow-scrolling: touch;
-
-        /* Fixes scrollbar disappearing when "Show scroll bars: Always" enabled in Safari */
-        box-shadow: 0 0 0 white;
-      }
-    </style>
-
     <template id="dropdown-template" is="dom-if" if="[[_renderDropdown]]">
+      <style>
+        #scroller {
+          overflow: auto;
+
+          /* Fixes item background from getting on top of scrollbars on Safari */
+          transform: translate3d(0, 0, 0);
+
+          /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
+          -webkit-overflow-scrolling: touch;
+
+          /* Fixes scrollbar disappearing when "Show scroll bars: Always" enabled in Safari */
+          box-shadow: 0 0 0 white;
+        }
+      </style>
       <vaadin-combo-box-dropdown id="dropdown"
           hidden="[[_hidden(_items.*, loading)]]"
           position-target="[[positionTarget]]"
@@ -186,16 +185,6 @@ This program is available under Apache License Version 2.0, available at https:/
         this.$.dropdown.opened = !!(opened && (loading || this.$.dropdown.opened || items && items.length));
       }
 
-      ready() {
-        super.ready();
-        // IE11: when scrolling with mouse, the focus goes to the scroller.
-        // This causes the overlay closing due to defocusing the input field.
-        // Prevent focusing the scroller by setting `unselectable="on"`.
-        if (/Trident/.test(navigator.userAgent)) {
-          this._scroller.setAttribute('unselectable', 'on');
-        }
-      }
-
       _initDropdown() {
         this._renderDropdown = true;
         this.shadowRoot.querySelector('#dropdown-template').render();
@@ -211,6 +200,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
         // Prevent blurring the input when clicking inside the overlay.
         this.$.dropdown.$.overlay.addEventListener('mousedown', e => e.preventDefault());
+
+        // IE11: when scrolling with mouse, the focus goes to the scroller.
+        // This causes the overlay closing due to defocusing the input field.
+        // Prevent focusing the scroller by setting `unselectable="on"`.
+        if (/Trident/.test(navigator.userAgent)) {
+          this._scroller.setAttribute('unselectable', 'on');
+        }
       }
 
       _templateChanged(e) {

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -13,7 +13,7 @@ This program is available under Apache License Version 2.0, available at https:/
 <dom-module id="vaadin-combo-box-dropdown-wrapper">
   <template>
     <!-- Stamping the content is postponed until the combo box is opened for the first time -->
-    <template id="dropdown-template" is="dom-if" if="[[_renderDropdown]]">
+    <template id="dropdown-template" is="dom-if">
       <style>
         #scroller {
           overflow: auto;
@@ -187,8 +187,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _initDropdown() {
-        this._renderDropdown = true;
-        this.shadowRoot.querySelector('#dropdown-template').render();
+        const template = this.shadowRoot.querySelector('#dropdown-template');
+        template.if = true;
+        template.render();
 
         this.$.dropdown = this.shadowRoot.querySelector('#dropdown');
         this.$.dropdown.$.overlay = this.$.dropdown.shadowRoot.querySelector('#overlay');

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -75,7 +75,10 @@ This program is available under Apache License Version 2.0, available at https:/
 
       static get properties() {
         return {
-          opened: Boolean,
+          opened: {
+            type: Boolean,
+            observer: '_openedChanged'
+          },
 
           template: {
             type: Object,
@@ -102,10 +105,6 @@ This program is available under Apache License Version 2.0, available at https:/
            */
           theme: String
         };
-      }
-
-      static get observers() {
-        return ['_openedChanged(opened)'];
       }
 
       constructor() {
@@ -157,7 +156,11 @@ This program is available under Apache License Version 2.0, available at https:/
        * @event vaadin-combo-box-dropdown-closed
        */
 
-      _openedChanged(opened) {
+      _openedChanged(opened, oldValue) {
+        if (!!oldValue === !!opened) {
+          return;
+        }
+
         if (opened) {
           this.$.overlay.style.position = this._isPositionFixed(this.positionTarget) ? 'fixed' : 'absolute';
           this._setPosition();

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -157,7 +157,7 @@ This program is available under Apache License Version 2.0, available at https:/
        */
 
       _openedChanged(opened, oldValue) {
-        if (!!oldValue === !!opened) {
+        if (!!opened === !!oldValue) {
           return;
         }
 

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -230,7 +230,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
       this.addEventListener('focusout', e => {
         // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
-        if (e.relatedTarget === this.$.overlay.$.dropdown.$.overlay) {
+        if (this.$.overlay.$.dropdown && e.relatedTarget === this.$.overlay.$.dropdown.$.overlay) {
           e.composedPath()[0].focus();
           return;
         }

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -334,9 +334,10 @@
       });
 
       it('should toggle loading attributes to host and overlay', () => {
-        comboBox.open();comboBox.close();
         comboBox.loading = true;
         expect(comboBox.hasAttribute('loading')).to.be.true;
+
+        comboBox.open();
         expect(comboBox.$.overlay.$.dropdown.$.overlay.hasAttribute('loading')).to.be.true;
 
         comboBox.loading = false;
@@ -350,7 +351,9 @@
       });
 
       it('should not notify resize the dropdown if not opened', () => {
-        comboBox.open();comboBox.close();
+        comboBox.open();
+        comboBox.close();
+
         const resizeSpy = sinon.spy(comboBox.$.overlay.$.dropdown, 'notifyResize');
         comboBox.filteredItems = ['foo', 'bar', 'baz'];
 

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -334,6 +334,7 @@
       });
 
       it('should toggle loading attributes to host and overlay', () => {
+        comboBox.open();comboBox.close();
         comboBox.loading = true;
         expect(comboBox.hasAttribute('loading')).to.be.true;
         expect(comboBox.$.overlay.$.dropdown.$.overlay.hasAttribute('loading')).to.be.true;
@@ -349,6 +350,7 @@
       });
 
       it('should not notify resize the dropdown if not opened', () => {
+        comboBox.open();comboBox.close();
         const resizeSpy = sinon.spy(comboBox.$.overlay.$.dropdown, 'notifyResize');
         comboBox.filteredItems = ['foo', 'bar', 'baz'];
 

--- a/test/item-renderer.html
+++ b/test/item-renderer.html
@@ -83,21 +83,10 @@
     });
 
     describe('with template', () => {
-      let comboBox;
-
-      beforeEach(() => {
-        comboBox = fixture('with-template');
-        comboBox.items = ['foo', 'bar', 'baz'];
-      });
-      afterEach(() => comboBox.opened = false);
-
-      it('renderer should receive empty root when defined after template', () => {
-        comboBox.renderer = root => expect(root.firstChild).to.be.null;
-        comboBox.opened = true;
-      });
-
 
       it('should throw an error and remove renderer when added after template', () => {
+        const comboBox = fixture('with-template');
+        comboBox.items = ['foo', 'bar', 'baz'];
         comboBox._observer.flush();
         expect(() => comboBox.renderer = () => {}).to.throw(Error);
         expect(comboBox.renderer).to.be.not.ok;

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -447,10 +447,10 @@
           items.push(i.toString());
         }
 
+        comboBox.open();
         selector = comboBox.$.overlay._selector;
         comboBox.items = items;
 
-        comboBox.open();
         setTimeout(done, 1);
       });
 

--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -149,7 +149,9 @@
       });
 
       it('should not notify resize when not opened', () => {
-        comboBox.open();comboBox.close();
+        comboBox.open();
+        comboBox.close();
+
         const spy = sinon.spy();
         comboBox.$.overlay.$.dropdown.notifyResize = spy;
         comboBox.items = [1, 2, 3];
@@ -203,7 +205,8 @@
       beforeEach(() => {
         // These tests randomly fails in Edge when they are run from travis
         // unless we reset borders.
-        comboBox.open();comboBox.close();
+        comboBox.open();
+        comboBox.close();
         comboBox.$.overlay._selector.$.items.style.border = 'none';
       });
 

--- a/test/overlay-position.html
+++ b/test/overlay-position.html
@@ -149,6 +149,7 @@
       });
 
       it('should not notify resize when not opened', () => {
+        comboBox.open();comboBox.close();
         const spy = sinon.spy();
         comboBox.$.overlay.$.dropdown.notifyResize = spy;
         comboBox.items = [1, 2, 3];
@@ -202,6 +203,7 @@
       beforeEach(() => {
         // These tests randomly fails in Edge when they are run from travis
         // unless we reset borders.
+        comboBox.open();comboBox.close();
         comboBox.$.overlay._selector.$.items.style.border = 'none';
       });
 

--- a/test/scrolling.html
+++ b/test/scrolling.html
@@ -37,6 +37,9 @@
 
       describeIf(/Trident/.test(navigator.userAgent), 'IE11', () => {
         it('should have unselectable="on" for the scroller', () => {
+          combobox.open();
+          combobox.close();
+
           const scroller = combobox.$.overlay._scroller;
           expect(scroller.getAttribute('unselectable')).to.equal('on');
         });

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -51,7 +51,9 @@
     });
 
     it('should stop click events from bubbling outside the overlay', () => {
-      combobox.open();combobox.close();
+      combobox.open();
+      combobox.close();
+
       const clickSpy = sinon.spy();
       document.addEventListener('click', clickSpy);
       combobox.$.overlay._selector.dispatchEvent(new CustomEvent('click', {
@@ -74,7 +76,9 @@
     });
 
     it('should fire `selection-changed` after the scrolling grace period', done => {
-      combobox.open();combobox.close();
+      combobox.open();
+      combobox.close();
+
       const items = [];
       for (let i = 1; i < 50; i++) {
         items.push(i);

--- a/test/selecting-items.html
+++ b/test/selecting-items.html
@@ -51,6 +51,7 @@
     });
 
     it('should stop click events from bubbling outside the overlay', () => {
+      combobox.open();combobox.close();
       const clickSpy = sinon.spy();
       document.addEventListener('click', clickSpy);
       combobox.$.overlay._selector.dispatchEvent(new CustomEvent('click', {
@@ -73,6 +74,7 @@
     });
 
     it('should fire `selection-changed` after the scrolling grace period', done => {
+      combobox.open();combobox.close();
       const items = [];
       for (let i = 1; i < 50; i++) {
         items.push(i);

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -140,7 +140,9 @@
       // of the combobox when moved during open.
       it('should not leak combobox style scope to the overlay', () => {
         // Test only when style scope classes are used
-        combobox.open();combobox.close();
+        combobox.open();
+        combobox.close();
+
         if (overlay().classList.contains('style-scope') &&
             overlay().classList.contains('vaadin-combo-box')) {
           combobox.open();

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -140,6 +140,7 @@
       // of the combobox when moved during open.
       it('should not leak combobox style scope to the overlay', () => {
         // Test only when style scope classes are used
+        combobox.open();combobox.close();
         if (overlay().classList.contains('style-scope') &&
             overlay().classList.contains('vaadin-combo-box')) {
           combobox.open();

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -353,6 +353,29 @@
         expect(combobox.opened).to.be.false;
       });
     });
+
+    describe('lazy attach dropdown', () => {
+
+      const getDropdown = () => combobox.$.overlay.shadowRoot.querySelector('vaadin-combo-box-dropdown');
+
+      it('should not attach dropdown initially', () => {
+        expect(getDropdown()).not.to.exist;
+      });
+
+      it('should attach dropdown on open', () => {
+        combobox.open();
+        expect(getDropdown()).to.exist;
+      });
+
+      it('should not re-create dropdown', () => {
+        combobox.open();
+        const dropdown = getDropdown();
+        combobox.close();
+        expect(getDropdown()).to.equal(dropdown);
+        combobox.open();
+        expect(getDropdown()).to.equal(dropdown);
+      });
+    });
   });
 </script>
 

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -76,7 +76,9 @@
       });
 
       it('should prevent default on overlay down', () => {
-        comboBox.open();comboBox.close();
+        comboBox.open();
+        comboBox.close();
+
         const e = new CustomEvent('mousedown', {bubbles: true});
         const spy = sinon.spy(e, 'preventDefault');
         comboBox.$.overlay.$.dropdown.$.overlay.dispatchEvent(e);
@@ -164,7 +166,9 @@
       beforeEach(() => comboBox = fixture('combobox-light-theme'));
 
       it('should propagate theme attribute to overlay', () => {
-        comboBox.open();comboBox.close();
+        comboBox.open();
+        comboBox.close();
+
         expect(comboBox.$.overlay.$.dropdown.$.overlay.getAttribute('theme')).to.equal('foo');
       });
 

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -76,6 +76,7 @@
       });
 
       it('should prevent default on overlay down', () => {
+        comboBox.open();comboBox.close();
         const e = new CustomEvent('mousedown', {bubbles: true});
         const spy = sinon.spy(e, 'preventDefault');
         comboBox.$.overlay.$.dropdown.$.overlay.dispatchEvent(e);
@@ -163,6 +164,7 @@
       beforeEach(() => comboBox = fixture('combobox-light-theme'));
 
       it('should propagate theme attribute to overlay', () => {
+        comboBox.open();comboBox.close();
         expect(comboBox.$.overlay.$.dropdown.$.overlay.getAttribute('theme')).to.equal('foo');
       });
 

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -262,6 +262,10 @@
           expect(comboBox.hasAttribute('focused')).to.be.false;
         });
 
+        it('should not throw on focusout', () => {
+          expect(() => comboBox.dispatchEvent(new Event('focusout'))).not.to.throw(Error);
+        });
+
         describe('methods', () => {
           it('should focus the input with focus method', () => {
             comboBox.focus();

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -245,7 +245,9 @@
         });
 
         it('should not open the overlay after clearing the value', () => {
-          comboBox.open();comboBox.close();
+          comboBox.open();
+          comboBox.close();
+
           const overlayElement = comboBox.$.overlay.$.dropdown.$.overlay;
           comboBox.value = 'foo';
 
@@ -276,8 +278,13 @@
         });
 
         describe('touch-devices', () => {
+
+          beforeEach(() => {
+            comboBox.open();
+            comboBox.close();
+          });
+
           it('should blur the input on touchend', () => {
-            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -286,7 +293,6 @@
           });
 
           it('should blur the input on touchmove', () => {
-            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -295,7 +301,6 @@
           });
 
           it('should not blur the input on touchstart', () => {
-            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -327,7 +332,9 @@
         });
 
         it('should propagate theme attribute to overlay', () => {
-          comboBox.open();comboBox.close();
+          comboBox.open();
+          comboBox.close();
+
           expect(comboBox.$.overlay.$.dropdown.$.overlay.getAttribute('theme')).to.equal('foo');
         });
 

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -245,6 +245,7 @@
         });
 
         it('should not open the overlay after clearing the value', () => {
+          comboBox.open();comboBox.close();
           const overlayElement = comboBox.$.overlay.$.dropdown.$.overlay;
           comboBox.value = 'foo';
 
@@ -276,6 +277,7 @@
 
         describe('touch-devices', () => {
           it('should blur the input on touchend', () => {
+            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -284,6 +286,7 @@
           });
 
           it('should blur the input on touchmove', () => {
+            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -292,6 +295,7 @@
           });
 
           it('should not blur the input on touchstart', () => {
+            comboBox.open();comboBox.close();
             comboBox.focus();
 
             const spy = sinon.spy(comboBox.inputElement, 'blur');
@@ -323,6 +327,7 @@
         });
 
         it('should propagate theme attribute to overlay', () => {
+          comboBox.open();comboBox.close();
           expect(comboBox.$.overlay.$.dropdown.$.overlay.getAttribute('theme')).to.equal('foo');
         });
 


### PR DESCRIPTION
This is a performance improvement.

When attaching a lot of combo boxes at once, the initial render can take a lot of time. Most of the time is spent on executing logic related to the overlay. This functionality is not needed until the overlay is opened, and it is wasted effort for any combo box on the page that the user doesn't open.

As a trade-off the first opening takes a bit longer. But the bigger problem was the huge delay caused by initializing a lot of combo boxes at once.

I ran a couple of tests by attaching 100 combo boxes, without and with this improvement. The rendering time improved enormously:
- Chrome: 1,960ms -> 249ms (down by 87%)
- Edge: 79,250ms -> 2,820ms (down by 96%)

Fixes #748

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/750)
<!-- Reviewable:end -->
