### PR TITLE
Remove extra filteredItems when size decreases

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -183,7 +183,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _sizeChanged(size = 0) {
-      const filteredItems = (this.filteredItems || []).slice(0);
+      const filteredItems = (this.filteredItems || []).slice(0, size);
       for (let i = 0; i < size; i++) {
         filteredItems[i] = filteredItems[i] !== undefined ? filteredItems[i] : this.__placeHolder;
       }

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -299,6 +299,24 @@
               expect(comboBox.selectedItem).to.not.be.instanceOf(Vaadin.ComboBoxPlaceholder);
             });
           });
+
+          describe('changing dataProvider', () => {
+            it('should have correct items after changing dataProvider to return less items', () => {
+              comboBox.dataProvider = (params, callback) => callback(['foo', 'bar'], 2);
+              comboBox.open();
+              comboBox.close();
+
+              comboBox.clearCache();
+              comboBox.dataProvider = (params, callback) => callback(['baz'], 1);
+              comboBox.open();
+
+              expect(comboBox.filteredItems).to.eql(['baz']);
+              const visibleItems = Array.from(
+                comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item'))
+                .filter(item => !item.hidden);
+              expect(visibleItems.map(item => item.$.content.innerText)).to.eql(['baz']);
+            });
+          });
         });
 
         describe('pageSize', () => {
@@ -349,6 +367,15 @@
             comboBox.opened = true;
             comboBox.dataProvider = spyDataProvider;
             expect(comboBox.size).to.equal(SIZE);
+          });
+
+          it('should remove extra filteredItems when decreasing size', () => {
+            comboBox.dataProvider = (params, callback) =>
+              callback(['foo', 'bar'], 2);
+            comboBox.open();
+
+            comboBox.size = 1;
+            expect(comboBox.filteredItems).to.eql(['foo']);
           });
         });
 


### PR DESCRIPTION
This is a fix for a bug found in the Flow component:
https://github.com/vaadin/vaadin-combo-box-flow/issues/177

Clearing the cache and returning less items than previously from the
dataProvider resulted in extra placeholder items.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/771)
<!-- Reviewable:end -->
