### PR TITLE
Don't request empty loaded page again

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -90,7 +90,7 @@ This program is available under Apache License Version 2.0, available at https:/
         const index = e.detail.index;
         if (index !== undefined) {
           const page = this._getPageForIndex(index);
-          if (!this._hasPage(page)) {
+          if (this._shouldLoadPage(page)) {
             this._loadPage(page);
           }
         }
@@ -106,17 +106,22 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _ensureFirstPage(opened) {
-      if (opened && !this._hasPage(0)) {
+      if (opened && this._shouldLoadPage(0)) {
         this._loadPage(0);
       }
     }
 
-    _hasPage(page) {
+    _shouldLoadPage(page) {
       if (!this.filteredItems) {
-        return false;
+        return true;
       }
+
       const loadedItem = this.filteredItems[page * this.pageSize];
-      return loadedItem !== undefined && !(loadedItem instanceof Vaadin.ComboBoxPlaceholder);
+      if (loadedItem !== undefined) {
+        return loadedItem instanceof Vaadin.ComboBoxPlaceholder;
+      } else {
+        return this.size === undefined;
+      }
     }
 
     _loadPage(page) {

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -250,6 +250,23 @@
               const params = spyDataProvider.lastCall.args[0];
               expect(params.filter).to.equal('');
             });
+
+            it('should not request loaded page again', () => {
+              comboBox.dataProvider = spyDataProvider;
+              comboBox.open();
+              comboBox.close();
+              comboBox.open();
+              expect(spyDataProvider).to.be.calledOnce;
+            });
+
+            it('should not request empty loaded page again', () => {
+              const dp = sinon.spy((params, callback) => callback([], 0));
+              comboBox.dataProvider = dp;
+              comboBox.open();
+              comboBox.close();
+              comboBox.open();
+              expect(dp).to.be.calledOnce;
+            });
           });
 
           describe('async', () => {


### PR DESCRIPTION
Previously, combobox didn't request a page again if it was already
loaded, but this logic did not apply if the returned array was empty.

This caused a bug in the Flow component, as the Flow dataprovider
doesn't return the empty array again after it has already given this
data to the client. This left the combobox hanging in loading state.

Flow component issue:
https://github.com/vaadin/vaadin-combo-box-flow/issues/178

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/772)
<!-- Reviewable:end -->
