### PR TITLE
Revert "Close the overlay if size is 0 after data provider callback"

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -150,9 +150,6 @@ This program is available under Apache License Version 2.0, available at https:/
             if (Object.keys(this._pendingRequests).length === 0) {
               this.loading = false;
             }
-            if (!this.size) {
-              this.opened = false;
-            }
           }
         };
         this._pendingRequests[page] = callback;

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -111,12 +111,6 @@
             expect(comboBox.items).to.be.undefined;
           });
 
-          it('should close if empty result set is received', () => {
-            comboBox.dataProvider = (params, cb) => cb([], 0);
-            comboBox.opened = true;
-            expect(comboBox.opened).to.be.false;
-          });
-
           describe('when open', () => {
             beforeEach(() => comboBox.opened = true);
 


### PR DESCRIPTION
Fixes https://github.com/vaadin/vaadin-combo-box/issues/769

…(#752)

This reverts commit 6a94726147c12c1ca2e90f8f0a85bb22677c66b5.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/773)
<!-- Reviewable:end -->
