### PR TITLE
Force next page request after clearCache

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -112,7 +112,8 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _shouldLoadPage(page) {
-      if (!this.filteredItems) {
+      if (!this.filteredItems || this._forceNextRequest) {
+        this._forceNextRequest = false;
         return true;
       }
 
@@ -181,6 +182,8 @@ This program is available under Apache License Version 2.0, available at https:/
       this.filteredItems = filteredItems;
       if (this.opened) {
         this._loadPage(0);
+      } else {
+        this._forceNextRequest = true;
       }
     }
 

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -731,6 +731,24 @@
               expect(pages).to.contain(1);
             });
           });
+
+          describe('after empty data set loaded', () => {
+
+            const emptyDataProvider = sinon.spy((params, callback) => callback([], 0));
+
+            beforeEach(() => {
+              comboBox.dataProvider = emptyDataProvider;
+              comboBox.open();
+              comboBox.close();
+              emptyDataProvider.reset();
+            });
+
+            it('should request first page on open', () => {
+              comboBox.clearCache();
+              comboBox.open();
+              expect(emptyDataProvider).to.be.calledOnce;
+            });
+          });
         });
       };
 


### PR DESCRIPTION
Otherwise, if the dataProvider has returned an empty data set
previously, new data is not requested when opening the overlay after
clearCache()

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/774)
<!-- Reviewable:end -->
