### PR TITLE
Replace dom-if with disable upgrade, delay scroll position adjustment

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -12,51 +12,50 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <dom-module id="vaadin-combo-box-dropdown-wrapper">
   <template>
-    <!-- Stamping the content is postponed until the combo box is opened for the first time -->
-    <template id="dropdown-template" is="dom-if">
-      <vaadin-combo-box-dropdown id="dropdown"
-          hidden="[[_hidden(_items.*, loading)]]"
-          position-target="[[positionTarget]]"
-          on-template-changed="_templateChanged"
-          on-position-changed="_setOverlayHeight"
-          theme="[[theme]]">
-        <template>
-          <style>
-            #scroller {
-              overflow: auto;
+    <vaadin-combo-box-dropdown id="dropdown"
+        hidden="[[_hidden(_items.*, loading)]]"
+        position-target="[[positionTarget]]"
+        on-template-changed="_templateChanged"
+        on-position-changed="_setOverlayHeight"
+        disable-upgrade
+        theme="[[theme]]">
+      <template>
+        <style>
+          #scroller {
+            overflow: auto;
 
-              /* Fixes item background from getting on top of scrollbars on Safari */
-              transform: translate3d(0, 0, 0);
+            /* Fixes item background from getting on top of scrollbars on Safari */
+            transform: translate3d(0, 0, 0);
 
-              /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
-              -webkit-overflow-scrolling: touch;
+            /* Enable momentum scrolling on iOS (iron-list v1.2+ no longer does it for us) */
+            -webkit-overflow-scrolling: touch;
 
-              /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
-              box-shadow: 0 0 0 white;
-            }
-          </style>
-          <div id="scroller" on-click="_stopPropagation">
-            <iron-list id="selector" role="listbox" items="[[_getItems(opened, _items)]]" scroll-target="[[_scroller]]">
-              <template>
-                <vaadin-combo-box-item
-                  on-click="_onItemClick"
-                  index="[[__requestItemByIndex(item, index)]]"
-                  item="[[item]]"
-                  label="[[getItemLabel(item, _itemLabelPath)]]"
-                  selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"
-                  renderer="[[renderer]]"
-                  role$="[[_getAriaRole(index)]]"
-                  aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
-                  focused="[[_isItemFocused(_focusedIndex,index)]]"
-                  tabindex="-1"
-                  theme$="[[theme]]">
-                </vaadin-combo-box-item>
-              </template>
-            </iron-list>
-          </div>
-        </template>
-      </vaadin-combo-box-dropdown>
-    </template>
+            /* Fixes scrollbar disappearing when 'Show scroll bars: Always' enabled in Safari */
+            box-shadow: 0 0 0 white;
+          }
+        </style>
+        <div id="scroller" on-click="_stopPropagation">
+          <iron-list id="selector" role="listbox" items="[[_getItems(opened, _items)]]" scroll-target="[[_scroller]]">
+            <template>
+              <vaadin-combo-box-item
+                on-click="_onItemClick"
+                index="[[__requestItemByIndex(item, index)]]"
+                item="[[item]]"
+                label="[[getItemLabel(item, _itemLabelPath)]]"
+                selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"
+                renderer="[[renderer]]"
+                role$="[[_getAriaRole(index)]]"
+                aria-selected$="[[_getAriaSelected(_focusedIndex,index)]]"
+                focused="[[_isItemFocused(_focusedIndex,index)]]"
+                tabindex="-1"
+                theme$="[[theme]]">
+              </vaadin-combo-box-item>
+            </template>
+          </iron-list>
+        </div>
+      </template>
+    </vaadin-combo-box-dropdown>
+
   </template>
 </dom-module>
 
@@ -173,7 +172,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _openedChanged(opened, items, loading) {
-        if (!this.$.dropdown) {
+        if (this.$.dropdown.hasAttribute('disable-upgrade')) {
           if (!opened) {
             return;
           } else {
@@ -186,11 +185,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _initDropdown() {
-        const template = this.shadowRoot.querySelector('#dropdown-template');
-        template.if = true;
-        template.render();
-
-        this.$.dropdown = this.shadowRoot.querySelector('#dropdown');
+        this.$.dropdown.removeAttribute('disable-upgrade');
 
         this._templateChanged();
         this._loadingChanged(this.loading);
@@ -210,7 +205,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _templateChanged(e) {
-        if (!this.$.dropdown) {
+        if (this.$.dropdown.hasAttribute('disable-upgrade')) {
           return;
         }
 
@@ -219,7 +214,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _loadingChanged(loading) {
-        if (!this.$.dropdown) {
+        if (this.$.dropdown.hasAttribute('disable-upgrade')) {
           return;
         }
 

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -5,6 +5,7 @@ This program is available under Apache License Version 2.0, available at https:/
 -->
 
 <link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../polymer/lib/mixins/disable-upgrade-mixin.html">
 <link rel="import" href="../../vaadin-overlay/src/vaadin-overlay.html">
 <link rel="import" href="../../iron-resizable-behavior/iron-resizable-behavior.html">
 
@@ -68,7 +69,9 @@ This program is available under Apache License Version 2.0, available at https:/
      * @memberof Vaadin
      * @private
      */
-    class ComboBoxDropdownElement extends Polymer.mixinBehaviors(Polymer.IronResizableBehavior, Polymer.Element) {
+    class ComboBoxDropdownElement extends Polymer.DisableUpgradeMixin(
+      Polymer.mixinBehaviors(Polymer.IronResizableBehavior, Polymer.Element)) {
+
       static get is() {
         return 'vaadin-combo-box-dropdown';
       }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -231,7 +231,8 @@ This program is available under Apache License Version 2.0, available at https:/
 
       this.addEventListener('focusout', e => {
         // Fixes the problem with `focusout` happening when clicking on the scroll bar on Edge
-        if (this.$.overlay.$.dropdown && e.relatedTarget === this.$.overlay.$.dropdown.$.overlay) {
+        const dropdown = this.$.overlay.$.dropdown;
+        if (dropdown && dropdown.$ && e.relatedTarget === dropdown.$.overlay) {
           e.composedPath()[0].focus();
           return;
         }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -548,8 +548,12 @@ This program is available under Apache License Version 2.0, available at https:/
 
       // Ensure metrics are up-to-date
       this.$.overlay.updateViewportBoundaries();
-      Polymer.Async.microTask.run(() => this.$.overlay.adjustScrollPosition());
+      // Force iron-list to create reusable nodes. Otherwise it will only start
+      // doing that in scroll listener, which is especially slow in Edge.
+      this.$.overlay._selector._increasePoolIfNeeded();
       setTimeout(() => this._resizeDropdown(), 1);
+      // Defer scroll position adjustment to prevent freeze in Edge
+      window.requestAnimationFrame(() => this.$.overlay.adjustScrollPosition());
 
 
       // _detectAndDispatchChange() should not consider value changes done before opening

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -22,6 +22,7 @@
     "fire": false,
     "fireMousedownMouseupClick": false,
     "getCustomPropertyValue": false,
+    "onceScrolled": false,
     "System": false,
     "HTMLImports": false,
     "MockInteractions": false,

--- a/test/common.js
+++ b/test/common.js
@@ -34,6 +34,18 @@ var fireMousedownMouseupClick = (node) => {
   fire('click', node);
 };
 
+var onceScrolled = (scroller) => {
+  return new Promise(resolve => {
+    const listener = () => {
+      scroller.removeEventListener('scroll', listener);
+      setTimeout(() => {
+        resolve();
+      });
+    };
+    scroller.addEventListener('scroll', listener);
+  });
+};
+
 var describeSkipIf = (bool, title, callback) => {
   bool = typeof bool == 'function' ? bool() : bool;
   if (bool) {

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -125,9 +125,11 @@
         setInputValue('b');
 
         // first scroll after open is async
-        setTimeout(() => {
-          expect(spy.callCount).to.eql(1); // scrolls once on open
-          done();
+        window.requestAnimationFrame(() => {
+          setTimeout(() => {
+            expect(spy.callCount).to.eql(1); // scrolls once on open
+            done();
+          }, 1);
         });
       });
 

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -530,7 +530,7 @@
 
         comboBox.open();
 
-        setTimeout(() => {
+        onceScrolled(comboBox.$.overlay._scroller).then(() => {
           expect(selector.firstVisibleIndex).to.be.within(50 - comboBox.$.overlay._visibleItemsCount(), 50);
           done();
         });

--- a/test/scrolling.html
+++ b/test/scrolling.html
@@ -85,10 +85,10 @@
           combobox.value = combobox.items[50];
           combobox.open();
 
-          setTimeout(() => {
+          onceScrolled(combobox.$.overlay._scroller).then(() => {
             expectSelectedItemPositionToBeVisible();
             done();
-          }, 1);
+          });
         });
 
         it('should make selected item visible after reopen', done => {

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -354,26 +354,21 @@
       });
     });
 
-    describe('lazy attach dropdown', () => {
+    describe('lazy upgrade dropdown', () => {
 
       const getDropdown = () => combobox.$.overlay.shadowRoot.querySelector('vaadin-combo-box-dropdown');
 
-      it('should not attach dropdown initially', () => {
-        expect(getDropdown()).not.to.exist;
+      it('should have disable-upgrade attribute initially', () => {
+        const dropdown = getDropdown();
+        expect(dropdown.hasAttribute('disable-upgrade')).to.be.true;
+        expect(dropdown.$).to.be.not.ok;
       });
 
-      it('should attach dropdown on open', () => {
-        combobox.open();
-        expect(getDropdown()).to.exist;
-      });
-
-      it('should not re-create dropdown', () => {
+      it('should remove disable-upgrade attribute on open', () => {
         combobox.open();
         const dropdown = getDropdown();
-        combobox.close();
-        expect(getDropdown()).to.equal(dropdown);
-        combobox.open();
-        expect(getDropdown()).to.equal(dropdown);
+        expect(dropdown.hasAttribute('disable-upgrade')).to.be.false;
+        expect(dropdown.$).to.be.ok;
       });
     });
   });


### PR DESCRIPTION
This makes combo-box opening faster at least in my virtual machine, although it still takes 1 second to adjust scroll after overlay opening.

The `disable-upgrade` change is also intended to make the initial opening faster, and especially avoid one extra `Polymer.flush` call caused by `render` but it does not seem to help much by itself.

Connected to #767

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/776)
<!-- Reviewable:end -->
