### PR TITLE
Close overlay before setting selectedItem

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -866,12 +866,12 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
 
-      if (this.selectedItem !== e.detail.item) {
-        this.selectedItem = e.detail.item;
-      }
-
       if (this.opened) {
         this.close();
+      }
+
+      if (this.selectedItem !== e.detail.item) {
+        this.selectedItem = e.detail.item;
       }
     }
 

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -283,9 +283,15 @@
             });
 
             it('should not be invoked if items are filtered', () => {
-              comboBox.inputElement.value = '1';
-              comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+              // workaround for applying filter for combo-box-light
+              if (comboBox.inputElement.tagName === 'IRON-INPUT') {
+                comboBox.inputElement._initSlottedInput();
+                comboBox.inputElement.inputElement.value = '1';
+              } else {
+                comboBox.inputElement.value = '1';
+              }
 
+              comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
               Polymer.flush();
               spyDataProvider.reset();
 

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -37,13 +37,15 @@
     describe('lazy loading', () => {
       const DEFAULT_PAGE_SIZE = 50;
       const SIZE = 200;
+      const allItems = Array(...new Array(SIZE)).map((_, i) => `item ${i}`);
       let dataProviderItems;
 
       const dataProvider = (params, callback) => {
+        const filteredItems = allItems.filter(item => item.indexOf(params.filter) > -1);
+        const size = filteredItems.length;
         const offset = params.page * params.pageSize;
-        const n = Math.min(offset + params.pageSize, SIZE) - offset;
-        dataProviderItems = Array(...new Array(n)).map((_, i) => `item ${offset + i}`);
-        callback(dataProviderItems, SIZE);
+        dataProviderItems = filteredItems.slice(offset, offset + params.pageSize);
+        callback(dataProviderItems, size);
       };
 
       const objectDataProvider = (params, callback) => {
@@ -261,6 +263,37 @@
               comboBox.open();
               expect(dp).to.be.calledOnce;
             });
+          });
+
+          describe('when selecting item', () => {
+
+            const clickFirstItem = () => comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item').click();
+
+            beforeEach(() => {
+              comboBox.dataProvider = spyDataProvider;
+              comboBox.open();
+              Polymer.flush();
+            });
+
+            it('should not be invoked', () => {
+              spyDataProvider.reset();
+              clickFirstItem();
+              expect(comboBox.selectedItem).to.eql('item 0');
+              expect(spyDataProvider.callCount).to.eql(0);
+            });
+
+            it('should not be invoked if items are filtered', () => {
+              comboBox.inputElement.value = '1';
+              comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+
+              Polymer.flush();
+              spyDataProvider.reset();
+
+              clickFirstItem();
+              expect(comboBox.selectedItem).to.eql('item 1');
+              expect(spyDataProvider.callCount).to.eql(0);
+            });
+
           });
 
           describe('async', () => {


### PR DESCRIPTION
Otherwise, the observer of selectedItem resets the filter, which causes
the dataProvider to be called, because combo box still thinks it's open.

Fix #783

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/785)
<!-- Reviewable:end -->
