### PR TITLE
fix: bind value correctly when using attr-for-value

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -605,13 +605,17 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    get _propertyForValue() {
+      return 'value';
+    }
+
     /**
      *  Filtering and items handling
      */
     _inputValueChanged(e) {
       // Handle only input events from our inputElement.
       if (e.composedPath().indexOf(this.inputElement) !== -1) {
-        this._inputElementValue = this.inputElement.value;
+        this._inputElementValue = this.inputElement[this._propertyForValue];
         this._filterFromInput();
       }
     }
@@ -707,7 +711,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         // Could not be defined in 1.x because ready is called after all prop-setters
         if (this.inputElement) {
-          this.inputElement.value = this._inputElementValue;
+          this.inputElement[this._propertyForValue] = this._inputElementValue;
         }
       }
 

--- a/test/my-input.html
+++ b/test/my-input.html
@@ -1,0 +1,36 @@
+<!--
+  This custom element is needed for testing the "attr-for-value" feature of
+  <vaadin-combo-box-light>
+-->
+<link rel="import" href="../../polymer/polymer-element.html">
+<script>
+  class MyInput extends Polymer.Element {
+    static get is() {
+      return 'my-input';
+    }
+
+    static get template() {
+      const {html} = Polymer;
+      return html`
+      <style>
+        :host {
+          display: inline-block;
+        }
+      </style>
+      <iron-input id="input" bind-value="{{customValue}}">
+        <input>
+      </iron-input>
+      `;
+    }
+  
+    static get properties() {
+      return {
+        customValue: {
+          type: String,
+          notify: true
+        }
+      };
+    }
+  }
+  window.customElements.define('my-input', MyInput);
+</script>

--- a/test/my-input.html
+++ b/test/my-input.html
@@ -3,34 +3,32 @@
   <vaadin-combo-box-light>
 -->
 <link rel="import" href="../../polymer/polymer-element.html">
-<script>
-  class MyInput extends Polymer.Element {
-    static get is() {
-      return 'my-input';
-    }
+<dom-module id="my-input">
+  <template>
+    <style>
+      :host {
+        display: inline-block;
+      }
+    </style>
+    <iron-input id="input" bind-value="{{customValue}}">
+      <input>
+    </iron-input>
+  </template>
+  <script>
+    class MyInput extends Polymer.Element {
+      static get is() {
+        return 'my-input';
+      }
 
-    static get template() {
-      const {html} = Polymer;
-      return html`
-      <style>
-        :host {
-          display: inline-block;
-        }
-      </style>
-      <iron-input id="input" bind-value="{{customValue}}">
-        <input>
-      </iron-input>
-      `;
+      static get properties() {
+        return {
+          customValue: {
+            type: String,
+            notify: true
+          }
+        };
+      }
     }
-  
-    static get properties() {
-      return {
-        customValue: {
-          type: String,
-          notify: true
-        }
-      };
-    }
-  }
-  window.customElements.define('my-input', MyInput);
-</script>
+    window.customElements.define('my-input', MyInput);
+  </script>
+</dom-module>

--- a/test/my-input.html
+++ b/test/my-input.html
@@ -3,6 +3,7 @@
   <vaadin-combo-box-light>
 -->
 <link rel="import" href="../../polymer/polymer-element.html">
+<link rel="import" href="../../iron-input/iron-input.html">
 <dom-module id="my-input">
   <template>
     <style>

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -65,7 +65,45 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="combobox-light-attr-for-value">
+    <template>
+      <vaadin-combo-box-light attr-for-value="custom-value">
+        <my-input class="input"></my-input>
+      </vaadin-combo-box-light>
+    </template>
+  </test-fixture>
+
   <script>
+    class MyInput extends Polymer.Element {
+      static get is() {
+        return 'my-input';
+      }
+
+      static get template() {
+        const {html} = Polymer;
+        return html`
+        <style>
+          :host {
+            display: inline-block;
+          }
+        </style>
+        <iron-input id="input" bind-value="{{customValue}}">
+          <input>
+        </iron-input>
+        `;
+      }
+    
+      static get properties() {
+        return {
+          customValue: {
+            type: String,
+            notify: true
+          }
+        };
+      }
+    }
+    window.customElements.define('my-input', MyInput);
+
     describe('vaadin-combo-box-light', () => {
       let comboBox, ironInput;
 
@@ -80,7 +118,7 @@
           expect(comboBox.inputElement).to.eql(ironInput);
         });
 
-        it('should bind the input value correctly', () => {
+        it('should bind the input value correctly when setting combo box value', () => {
           // Empty string by default.
           expect(comboBox._inputElementValue).to.eql('');
           expect(ironInput.value).to.eql('');
@@ -138,6 +176,66 @@
             expect(comboBox.value).to.equal('foo');
             done();
           }, {emulateTouch: true});
+        });
+      });
+    });
+
+    describe('vaadin-combobox-light-attr-for-value', () => {
+      let comboBox, customInput, ironInput, nativeInput;
+
+      function whenIronInputReady(ironInput, callback) {
+        if (ironInput.inputElement) {
+          callback();
+        } else {
+          ironInput.addEventListener('iron-input-ready', callback);
+        }
+      }
+
+      beforeEach(() => {
+        comboBox = fixture('combobox-light-attr-for-value');
+        comboBox.items = ['foo', 'bar', 'baz'];
+        customInput = comboBox.querySelector('.input');
+        ironInput = customInput.$.input;
+        nativeInput = ironInput.querySelector('input');
+      });
+
+      describe('using custom input with custom attr-for-value', () => {
+        it('should find the input element correctly', () => {
+          expect(comboBox.inputElement).to.eql(customInput);
+        });
+
+        it('should bind the input value correctly when setting combo box value', () => {
+          // Empty string by default.
+          expect(comboBox._inputElementValue).to.eql('');
+          expect(customInput.customValue).to.eql('');
+
+          comboBox.value = 'foo';
+          expect(comboBox._inputElementValue).to.eql('foo');
+          expect(customInput.customValue).to.eql('foo');
+        });
+
+        it('should bind the input value correctly when typing in input', done => {
+          // Empty string by default.
+          expect(comboBox._inputElementValue).to.eql('');
+          expect(customInput.customValue).to.eql('');
+
+          // We need to wait until <iron-input> is ready before trying to input text
+          // into the input, otherwise the test will fail when iron-input throws
+          // an error in `_onInput` because it tries to read `inputElement.value`
+          // but `inputElement` may still be undefined because iron-input hasn't yet
+          // detected the slotted <input> element.
+          whenIronInputReady(ironInput, () => {
+            // Simulate typing an option with a keyboard and confirming it via Enter
+            nativeInput.focus();
+            document.execCommand('insertText', false, 'foo');
+            MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
+
+            expect(comboBox.value).to.eql('foo');
+            expect(comboBox._inputElementValue).to.eql('foo');
+            expect(customInput.customValue).to.eql('foo');
+
+            done();
+          });
         });
       });
     });

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -154,14 +154,6 @@
     describe('vaadin-combobox-light-attr-for-value', () => {
       let comboBox, customInput, ironInput, nativeInput;
 
-      function whenIronInputReady(ironInput, callback) {
-        if (ironInput.inputElement) {
-          callback();
-        } else {
-          ironInput.addEventListener('iron-input-ready', callback);
-        }
-      }
-
       beforeEach(() => {
         comboBox = fixture('combobox-light-attr-for-value');
         comboBox.items = ['foo', 'bar', 'baz'];
@@ -185,35 +177,27 @@
           expect(customInput.customValue).to.eql('foo');
         });
 
-        it('should bind the input value correctly when getting input', done => {
+        it('should bind the input value correctly when getting input', () => {
           // Empty string by default.
           expect(comboBox._inputElementValue).to.eql('');
           expect(customInput.customValue).to.eql('');
           expect(nativeInput.value).to.eql('');
 
-          // We need to wait until <iron-input> is ready before trying to input text
-          // into the input, otherwise the test will fail when iron-input throws
-          // an error in `_onInput` because it tries to read `inputElement.value`
-          // but `inputElement` may still be undefined because iron-input hasn't yet
-          // detected the slotted <input> element.
-          whenIronInputReady(ironInput, () => {
-            // Use a timeout to get out of "iron-input-ready" event context, otherwise
-            // any thrown error (e.g. failed assertion) will result in a huge obscure
-            // error message in Firefox without any info about the assertion failure.
-            setTimeout(() => {
+          // Make sure the slotted <input> has been detected by <iron-input>
+          // before trying to modify the value of the <input>.
+          // Otherwise iron-input will throw an error (in `_onInput`) because
+          // it tries to read `inputElement.value` but `inputElement` is still
+          // undefined.
+          ironInput._observer.flush();
 
-              // Simulate typing an option with a keyboard and confirming it via Enter
-              nativeInput.value = 'foo';
-              fire('input', nativeInput);
-              MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
+          // Simulate typing an option with a keyboard and confirming it via Enter
+          nativeInput.value = 'foo';
+          fire('input', nativeInput);
+          MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
 
-              expect(comboBox.value).to.eql('foo');
-              expect(comboBox._inputElementValue).to.eql('foo');
-              expect(customInput.customValue).to.eql('foo');
-
-              done();
-            }, 0);
-          });
+          expect(comboBox.value).to.eql('foo');
+          expect(comboBox._inputElementValue).to.eql('foo');
+          expect(customInput.customValue).to.eql('foo');
         });
       });
     });

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -185,10 +185,11 @@
           expect(customInput.customValue).to.eql('foo');
         });
 
-        it('should bind the input value correctly when typing in input', done => {
+        it('should bind the input value correctly when getting input', done => {
           // Empty string by default.
           expect(comboBox._inputElementValue).to.eql('');
           expect(customInput.customValue).to.eql('');
+          expect(nativeInput.value).to.eql('');
 
           // We need to wait until <iron-input> is ready before trying to input text
           // into the input, otherwise the test will fail when iron-input throws
@@ -202,13 +203,7 @@
             setTimeout(() => {
 
               // Simulate typing an option with a keyboard and confirming it via Enter
-              nativeInput.focus();
-              const success = document.execCommand('insertText', false, 'foo');
-              if (!success && typeof nativeInput.setRangeText === 'function') {
-                // Needed for Firefox ("insertText" won't work)
-                nativeInput.setRangeText('foo');
-                nativeInput.selectionStart = nativeInput.selectionEnd = 'foo'.length;
-              }
+              nativeInput.value = 'foo';
               fire('input', nativeInput);
               MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
 

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -8,6 +8,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
   <link rel="import" href="common-imports.html">
+  <link rel="import" href="my-input.html">
   <script src="common.js"></script>
   <link rel="import" href="../vaadin-combo-box-light.html">
   <link rel="import" href="../../iron-input/iron-input.html">
@@ -74,36 +75,6 @@
   </test-fixture>
 
   <script>
-    class MyInput extends Polymer.Element {
-      static get is() {
-        return 'my-input';
-      }
-
-      static get template() {
-        const {html} = Polymer;
-        return html`
-        <style>
-          :host {
-            display: inline-block;
-          }
-        </style>
-        <iron-input id="input" bind-value="{{customValue}}">
-          <input>
-        </iron-input>
-        `;
-      }
-    
-      static get properties() {
-        return {
-          customValue: {
-            type: String,
-            notify: true
-          }
-        };
-      }
-    }
-    window.customElements.define('my-input', MyInput);
-
     describe('vaadin-combo-box-light', () => {
       let comboBox, ironInput;
 

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -196,16 +196,28 @@
           // but `inputElement` may still be undefined because iron-input hasn't yet
           // detected the slotted <input> element.
           whenIronInputReady(ironInput, () => {
-            // Simulate typing an option with a keyboard and confirming it via Enter
-            nativeInput.focus();
-            document.execCommand('insertText', false, 'foo');
-            MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
+            // Use a timeout to get out of "iron-input-ready" event context, otherwise
+            // any thrown error (e.g. failed assertion) will result in a huge obscure
+            // error message in Firefox without any info about the assertion failure.
+            setTimeout(() => {
 
-            expect(comboBox.value).to.eql('foo');
-            expect(comboBox._inputElementValue).to.eql('foo');
-            expect(customInput.customValue).to.eql('foo');
+              // Simulate typing an option with a keyboard and confirming it via Enter
+              nativeInput.focus();
+              const success = document.execCommand('insertText', false, 'foo');
+              if (!success && typeof nativeInput.setRangeText === 'function') {
+                // Needed for Firefox ("insertText" won't work)
+                nativeInput.setRangeText('foo');
+                nativeInput.selectionStart = nativeInput.selectionEnd = 'foo'.length;
+              }
+              fire('input', nativeInput);
+              MockInteractions.pressAndReleaseKeyOn(nativeInput, 13, null, 'Enter');
 
-            done();
+              expect(comboBox.value).to.eql('foo');
+              expect(comboBox._inputElementValue).to.eql('foo');
+              expect(customInput.customValue).to.eql('foo');
+
+              done();
+            }, 0);
           });
         });
       });


### PR DESCRIPTION
When using `attr-for-value` different than "value", the data binding of value wasn't fully working. This only happened to work with the `iron-input` example we have ("Replacing the Input" example) because `iron-input` also has a "value" property. When using a custom input with `attr-for-value` other than "value" the user was unable to change the value of the input by interacting with it via the keyboard. This is now also working.

Fixes #778

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/797)
<!-- Reviewable:end -->
