### PR TITLE
Fix duplicate custom-value-set events fired

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -247,7 +247,7 @@ This program is available under Apache License Version 2.0, available at https:/
       // 2.0 does not support 'overlay.selection-changed' syntax in listeners
       this.$.overlay.addEventListener('selection-changed', this._overlaySelectedItemChanged.bind(this));
 
-      this.addEventListener('vaadin-combo-box-dropdown-closed', this._onClosed.bind(this));
+      this.addEventListener('vaadin-combo-box-dropdown-closed', this.close.bind(this));
       this.addEventListener('vaadin-combo-box-dropdown-opened', this._onOpened.bind(this));
       this.addEventListener('keydown', this._onKeyDown.bind(this));
       this.addEventListener('click', this._onClick.bind(this));

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -177,6 +177,9 @@
         });
 
         describe('`custom-value-set` event', () => {
+
+          beforeEach(() => comboBox.items = ['a', 'b']);
+
           it('should be fired when custom value is set', () => {
             const spy = sinon.spy();
             comboBox.addEventListener('custom-value-set', spy);


### PR DESCRIPTION
The _onClosed function was running twice when the overlay was closed:
- once by reacting to the dropdown closing event
- another time by the opened property observer

Because of this, the custom-value-set event was fired twice.

This was not caught by the tests, because the test combo box didn't
have any items, so there was no overlay, which would be closed to make
the extra _onClosed call.

Fix https://github.com/vaadin/vaadin-combo-box-flow/issues/167

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/799)
<!-- Reviewable:end -->
