### PR TITLE
fix: don't fire custom-value-set on item click

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -876,6 +876,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       if (this.opened) {
+        this._focusedIndex = this.filteredItems.indexOf(e.detail.item);
         this.close();
       }
 

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -221,6 +221,16 @@
             comboBox.close();
             expect(comboBox.value).to.be.empty;
           });
+
+          it('should not be fired when clicking an item', () => {
+            const spy = sinon.spy();
+            comboBox.addEventListener('custom-value-set', spy);
+
+            comboBox.open();
+            comboBox.inputElement.value = 'a';
+            comboBox.$.overlay._selector.querySelector('vaadin-combo-box-item').click();
+            expect(spy).to.not.have.been.called;
+          });
         });
       });
 

--- a/wct.conf.js
+++ b/wct.conf.js
@@ -34,16 +34,17 @@ module.exports = {
 
   registerHooks: function(context) {
     const saucelabsPlatformsMobile = [
-      'iOS Simulator/iphone@11.3'
+      'iOS Simulator/iphone@12.2',
+      'iOS Simulator/iphone@10.3'
     ];
 
     const saucelabsPlatformsMicrosoft = [
-      'Windows 10/microsoftedge@17',
+      'Windows 10/microsoftedge@18',
       'Windows 10/internet explorer@11'
     ];
 
     const saucelabsPlatformsDesktop = [
-      'macOS 10.13/safari@11.1'
+      'macOS 10.13/safari@latest'
     ];
 
     const saucelabsPlatforms = [
@@ -56,10 +57,10 @@ module.exports = {
       {
         deviceName: 'Android GoogleAPI Emulator',
         platformName: 'Android',
-        platformVersion: '7.1',
+        platformVersion: '8.1',
         browserName: 'chrome'
       },
-      'iOS Simulator/ipad@11.3',
+      'iOS Simulator/ipad@12.2',
       'iOS Simulator/iphone@10.3',
       'Windows 10/chrome@latest',
       'Windows 10/firefox@latest'


### PR DESCRIPTION
By setting the _focusedIndex, vaadin-combo-box-mixin._onClosed knows
that it should select the existing item instead of firing
custom-value-set event.

fix #804 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/809)
<!-- Reviewable:end -->
