### PR TITLE
fix: reposition overlay after first page load

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -156,6 +156,9 @@ This program is available under Apache License Version 2.0, available at https:/
             if (Object.keys(this._pendingRequests).length === 0) {
               this.loading = false;
             }
+            if (page === 0 && this.__repositionOverlayDebouncer) {
+              setTimeout(() => this.__repositionOverlayDebouncer.flush());
+            }
           }
         };
         this._pendingRequests[page] = callback;

--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -156,8 +156,9 @@ This program is available under Apache License Version 2.0, available at https:/
             if (Object.keys(this._pendingRequests).length === 0) {
               this.loading = false;
             }
-            if (page === 0 && this.__repositionOverlayDebouncer) {
+            if (page === 0 && this.__repositionOverlayDebouncer && items.length > (this.__maxRenderedItems || 0)) {
               setTimeout(() => this.__repositionOverlayDebouncer.flush());
+              this.__maxRenderedItems = items.length;
             }
           }
         };

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -260,7 +260,7 @@
             });
 
             it('should render all visible items after delayed response', done => {
-              const items = [...Array(10).keys()].map(i => 'item ' + i);
+              const items = [...Array(10)].map((_, i) => 'item ' + i);
               comboBox.dataProvider = (params, callback) => {
                 setTimeout(() => {
                   callback(items, 10);

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -258,6 +258,23 @@
               comboBox.open();
               expect(dp).to.be.calledOnce;
             });
+
+            it('should render all visible items after delayed response', done => {
+              const items = [...Array(10).keys()].map(i => 'item ' + i);
+              comboBox.dataProvider = (params, callback) => {
+                setTimeout(() => {
+                  callback(items, 10);
+                  setTimeout(() => {
+                    const renderedTexts = Array.from(comboBox.$.overlay._selector
+                      .querySelectorAll('vaadin-combo-box-item'))
+                      .map(i => i.shadowRoot.querySelector('#content').innerText);
+                    expect(renderedTexts).to.eql(items);
+                    done();
+                  });
+                }, 50);
+              };
+              comboBox.open();
+            });
           });
 
           describe('when selecting item', () => {


### PR DESCRIPTION
only if the number of items to render has increased from a previous rendering

fix vaadin/vaadin-combo-box-flow#250

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/814)
<!-- Reviewable:end -->
