### PR TITLE
fix: always scroll to selected item on first open and flaky tests

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -350,6 +350,9 @@ This program is available under Apache License Version 2.0, available at https:/
       }
 
       _scrollIntoView(index) {
+        if (!(this.opened && index >= 0)) {
+          return;
+        }
         const visibleItemsCount = this._visibleItemsCount();
         if (visibleItemsCount === undefined) {
           // Scroller is not visible. Moving is unnecessary.
@@ -360,6 +363,9 @@ This program is available under Apache License Version 2.0, available at https:/
 
         if (index > this._selector.lastVisibleIndex - 1) {
           // Index is below the bottom, scrolling down. Make the item appear at the bottom.
+          // First scroll to target (will be at the top of the scroller) to make sure it's rendered.
+          this._selector.scrollToIndex(index);
+          // Then calculate the index for the following scroll (to get the target to bottom of the scroller).
           targetIndex = index - visibleItemsCount + 1;
         } else if (index > this._selector.firstVisibleIndex) {
           // The item is already visible, scrolling is unnecessary per se. But we need to trigger iron-list to set

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -385,15 +385,11 @@
         comboBox = fixture('combobox');
       });
 
-      it('should properly display all items in the selector', done => {
-        comboBox.opened = true;
-        setTimeout(() => {
-          comboBox.filteredItems = Array.apply(null, Array(20)).map((_, i) => `item${i}`);
-          setTimeout(() => {
-            expect(comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item').length).to.equal(20);
-            done();
-          }, 1);
-        });
+      it('should properly display all items in the selector', () => {
+        comboBox.open();
+        comboBox.filteredItems = Array.apply(null, Array(20)).map((_, i) => `item${i}`);
+        Polymer.flush();
+        expect(comboBox.$.overlay._selector.querySelectorAll('vaadin-combo-box-item').length).to.equal(20);
       });
     });
   });

--- a/test/index.html
+++ b/test/index.html
@@ -9,7 +9,7 @@
   <script src="test-suites.js"></script>
 </head>
 
-<body>
+<body style="min-height: 520px;">
   <script>
     WCT.loadSuites(window.VaadinComboBoxSuites);
   </script>

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -462,6 +462,7 @@
       });
 
       it('should scroll down after reaching the last visible item', () => {
+        selector.scrollToIndex(0);
         comboBox._focusedIndex = comboBox.$.overlay._visibleItemsCount() - 1;
         expect(selector.firstVisibleIndex).to.eql(0);
 


### PR DESCRIPTION
The scrolling fix made the broken filtering test fail in more cases (viewport sizes) so I wanted to fix the flaky tests in the same PR to get tests passing.

Fixes #815
Fixes #731.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/vaadin-combo-box/816)
<!-- Reviewable:end -->
