### PR TITLE
Reset scroll position for selector

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -845,6 +845,13 @@ This program is available under Apache License Version 2.0, available at https:/
         () => {
           const selector = this.$.overlay._selector;
           if (!selector._isClientFull()) {
+            // Due to the mismatch of the Y position of the item rendered
+            // at the top of the scrolling list with some specific scroll
+            // position values (2324, 3486, 6972, 60972, 95757 etc.)
+            // iron-list loops the increasing of the pool and adds
+            // too many items to the DOM.
+            // Adjusting scroll position to equal the current scrollTop value
+            // to avoid looping.
             selector._resetScrollPosition(selector._physicalTop);
           }
           this._resizeDropdown();

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -843,10 +843,14 @@ This program is available under Apache License Version 2.0, available at https:/
         // which is very slow in Edge
         Polymer.Async.timeOut.after(500),
         () => {
+          const selector = this.$.overlay._selector;
+          if (!selector._isClientFull()) {
+            selector._resetScrollPosition(selector._physicalTop);
+          }
           this._resizeDropdown();
           this.$.overlay.updateViewportBoundaries();
           this.$.overlay.ensureItemsRendered();
-          this.$.overlay._selector.notifyResize();
+          selector.notifyResize();
           Polymer.flush();
         }
       );


### PR DESCRIPTION
Connected to #825

The issue occurs when `dataProvider` callback asynchronously triggers the repositioning of the overlay and due to the mismatch of the Y position of the item rendered at the top of the scrolling list with some specific scroll position values (2324, 3486, 6972, 60972, 95757, 104451, 104722, 150937 etc.) at that point of time (`timeOut.after(500)`) `iron-list` loops the increasing of the pool and adds too many items to the DOM. 

The fix allows to check if there is a mismatch and adjust scroll position to equal the current `scrollTop` value.