### PR TITLE
updated pageSizeObserver to check for negative values

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -200,7 +200,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _pageSizeChanged(pageSize, oldPageSize) {
-      if (Math.floor(pageSize) !== pageSize || pageSize === 0) {
+      if (Math.floor(pageSize) !== pageSize || pageSize === 0 || pageSize < 0) {
         this.pageSize = oldPageSize;
         throw new Error('`pageSize` value must be an integer > 0');
       }

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -430,6 +430,12 @@
             expect(() => comboBox.pageSize = '10').to.throw('pageSize');
             expect(comboBox.pageSize).to.equal(123);
           });
+
+          it('should throw when set to negative value', () => {
+            comboBox.pageSize = 10;
+            expect(() => comboBox.pageSize = -1).to.throw('pageSize');
+            expect(comboBox.pageSize).to.equal(10);
+          });
         });
 
         describe('size', () => {


### PR DESCRIPTION
Added a check for negative values to the `pageSizeObserver`, such that it will not allow negative values to be set for `pageSize`. Similarly to how setting non-number values or 0 throws an exception, setting a negative value should throw one as well.

fixes #845 