### PR TITLE
refactor: do not use array in querySelector

### DIFF
--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -56,7 +56,7 @@ This program is available under Apache License Version 2.0, available at https:/
         super.ready();
         const loader = document.createElement('div');
         loader.setAttribute('part', 'loader');
-        const content = this.shadowRoot.querySelector(['[part~="content"]']);
+        const content = this.shadowRoot.querySelector('[part~="content"]');
         content.parentNode.insertBefore(loader, content);
       }
     }


### PR DESCRIPTION
Fixes #831. 

Somehow the browsers accept the array here, too. But apparently it breaks when minified.