### PR TITLE
Add autoOpenDisabled property

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -36,6 +36,11 @@ This program is available under Apache License Version 2.0, available at https:/
         },
 
         /**
+         * Set true to prevent the overlay from opening automatically.
+         */
+        autoOpenDisabled: Boolean,
+
+        /**
          * Set to true to disable this element.
          */
         disabled: {
@@ -366,7 +371,7 @@ This program is available under Apache License Version 2.0, available at https:/
       } else if (path.indexOf(this.inputElement) !== -1) {
         if (path.indexOf(this._toggleElement) > -1 && this.opened) {
           this.close();
-        } else {
+        } else if (path.indexOf(this._toggleElement) > -1 || !this.autoOpenDisabled) {
           this.open();
         }
       }
@@ -638,7 +643,7 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _filterFromInput(e) {
-      if (!this.opened && !e.__fromClearButton) {
+      if (!this.opened && !e.__fromClearButton && !this.autoOpenDisabled) {
         this.open();
       }
 
@@ -820,11 +825,13 @@ This program is available under Apache License Version 2.0, available at https:/
         return arr;
       }
 
-      return arr.filter(item => {
+      const filteredItems = arr.filter(item => {
         filter = filter ? filter.toString().toLowerCase() : '';
         // Check if item contains input value.
         return this._getItemLabel(item).toString().toLowerCase().indexOf(filter) > -1;
       });
+
+      return !filteredItems.length && this.autoOpenDisabled ? arr : filteredItems;
     }
 
     _selectItemForValue(value) {

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -329,7 +329,11 @@ This program is available under Apache License Version 2.0, available at https:/
      * Closes the dropdown list.
      */
     close() {
-      this.opened = false;
+      if (this.autoOpenDisabled && !this.opened) {
+        this._onClosed();
+      } else {
+        this.opened = false;
+      }
     }
 
     _openedChanged(value, old) {
@@ -495,7 +499,7 @@ This program is available under Apache License Version 2.0, available at https:/
     _onEnter(e) {
       // should close on enter when custom values are allowed, input field is cleared, or when an existing
       // item is focused with keyboard.
-      if (this.opened && (this.allowCustomValue || this._inputElementValue === '' || this._focusedIndex > -1)) {
+      if ((this.opened || this.autoOpenDisabled) && (this.allowCustomValue || this._inputElementValue === '' || this._focusedIndex > -1)) {
         this.close();
 
         // Do not submit the surrounding form.
@@ -507,7 +511,10 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onEscape(e) {
-      if (this.opened) {
+      if (this.autoOpenDisabled) {
+        this._focusedIndex = -1;
+        this.cancel();
+      } else if (this.opened) {
         this._stopPropagation(e);
 
         if (this._focusedIndex > -1) {
@@ -810,7 +817,7 @@ This program is available under Apache License Version 2.0, available at https:/
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
         this._setOverlayItems(this.filteredItems);
 
-        this._focusedIndex = this.opened ?
+        this._focusedIndex = this.opened || this.autoOpenDisabled ?
           this.$.overlay.indexOfLabel(this.filter) :
           this._indexOfValue(this.value, this.filteredItems);
 

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -278,7 +278,7 @@ This program is available under Apache License Version 2.0, available at https:/
           });
         }
       };
-  
+
       this.addEventListener('mousedown', bringToFrontListener);
       this.addEventListener('touchstart', bringToFrontListener);
     }
@@ -329,11 +329,7 @@ This program is available under Apache License Version 2.0, available at https:/
      * Closes the dropdown list.
      */
     close() {
-      if (this.autoOpenDisabled && !this.opened) {
-        this._onClosed();
-      } else {
-        this.opened = false;
-      }
+      this.opened = false;
     }
 
     _openedChanged(value, old) {
@@ -496,11 +492,19 @@ This program is available under Apache License Version 2.0, available at https:/
       }
     }
 
+    _closeOrCommit() {
+      if (this.autoOpenDisabled && !this.opened) {
+        this._commitValue();
+      } else {
+        this.close();
+      }
+    }
+
     _onEnter(e) {
       // should close on enter when custom values are allowed, input field is cleared, or when an existing
-      // item is focused with keyboard.
+      // item is focused with keyboard. If auto open is disabled, under the same conditions, commit value.
       if ((this.opened || this.autoOpenDisabled) && (this.allowCustomValue || this._inputElementValue === '' || this._focusedIndex > -1)) {
-        this.close();
+        this._closeOrCommit();
 
         // Do not submit the surrounding form.
         e.preventDefault();
@@ -559,7 +563,7 @@ This program is available under Apache License Version 2.0, available at https:/
       this._revertInputValueToValue();
       // In the next _detectAndDispatchChange() call, the change detection should not pass
       this._lastCommittedValue = this.value;
-      this.close();
+      this._closeOrCommit();
     }
 
     _onOpened() {
@@ -589,12 +593,15 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     _onClosed() {
-
       // Happens when the overlay is closed by clicking outside
       if (this.opened) {
         this.close();
       }
 
+      this._commitValue();
+    }
+
+    _commitValue() {
       if (this.$.overlay._items && this._focusedIndex > -1) {
         const focusedItem = this.$.overlay._items[this._focusedIndex];
         if (this.selectedItem !== focusedItem) {
@@ -936,7 +943,7 @@ This program is available under Apache License Version 2.0, available at https:/
         return;
       }
       if (!this._closeOnBlurIsPrevented) {
-        this.close();
+        this._closeOrCommit();
       }
     }
 

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -57,6 +57,15 @@
         expect(comboBox.opened).to.equal(true);
       });
 
+      it('should not open the popup if closed and autoOpenDisabled is true', () => {
+        comboBox.autoOpenDisabled = true;
+        comboBox.close();
+
+        setInputValue('foo');
+
+        expect(comboBox.opened).to.equal(false);
+      });
+
       it('should open the popup when the value of the input field is set to none', () => {
         comboBox.value = 'foo';
         comboBox.close();
@@ -65,6 +74,17 @@
         setInputValue('');
 
         expect(comboBox.opened).to.equal(true);
+      });
+
+      it('should not open the popup when the value of the input field is set to none and autoOpenDisabled is true', () => {
+        comboBox.autoOpenDisabled = true;
+        comboBox.value = 'foo';
+        comboBox.close();
+        expect(comboBox.opened).to.equal(false);
+
+        setInputValue('');
+
+        expect(comboBox.opened).to.equal(false);
       });
 
       it('should not change the value of the combobox', () => {

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -91,6 +91,18 @@
         expect(getFocusedIndex()).to.equal(-1);
       });
 
+      it('should open the overlay with arrow down when autoOpenDisabled is true', () => {
+        comboBox.autoOpenDisabled = true;
+        arrowDown();
+        expect(comboBox.opened).to.equal(true);
+      });
+
+      it('should open the overlay with arrow up when autoOpenDisabled is true', () => {
+        comboBox.autoOpenDisabled = true;
+        arrowUp();
+        expect(comboBox.opened).to.equal(true);
+      });
+
       it('should have focus on the selected item after opened', () => {
         comboBox.value = 'foo';
 

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -55,6 +55,19 @@
       }
     }
 
+    function inputChar(char) {
+      const target = comboBox.inputElement;
+      target.value += char;
+      MockInteractions.keyDownOn(target, char.charCodeAt(0));
+      target.dispatchEvent(new CustomEvent('input', {bubbles: true, composed: true}));
+    }
+
+    function inputText(text) {
+      for (var i = 0; i < text.length; i++) {
+        inputChar(text[i]);
+      }
+    }
+
     function arrowDown(cb) {
       pushKey(40, cb);
     }
@@ -89,18 +102,6 @@
 
         expect(comboBox.opened).to.equal(true);
         expect(getFocusedIndex()).to.equal(-1);
-      });
-
-      it('should open the overlay with arrow down when autoOpenDisabled is true', () => {
-        comboBox.autoOpenDisabled = true;
-        arrowDown();
-        expect(comboBox.opened).to.equal(true);
-      });
-
-      it('should open the overlay with arrow up when autoOpenDisabled is true', () => {
-        comboBox.autoOpenDisabled = true;
-        arrowUp();
-        expect(comboBox.opened).to.equal(true);
       });
 
       it('should have focus on the selected item after opened', () => {
@@ -555,6 +556,66 @@
           done();
         });
       });
+    });
+
+    describe('auto open disabled', () => {
+
+      beforeEach(() => {
+        comboBox.autoOpenDisabled = true;
+      });
+
+      it('should open the overlay with arrow down', () => {
+        arrowDown();
+        expect(comboBox.opened).to.equal(true);
+      });
+
+      it('should open the overlay with arrow up', () => {
+        arrowUp();
+        expect(comboBox.opened).to.equal(true);
+      });
+
+      it('should apply input value on focusout if input valid', () => {
+        inputText('FOO');
+        comboBox.dispatchEvent(new Event('focusout'));
+        expect(comboBox._inputElementValue).to.equal('foo');
+        expect(comboBox.value).to.equal('foo');
+      });
+
+      it('should apply input value on enter if input valid', () => {
+        inputText('FOO');
+        enter();
+        expect(comboBox._inputElementValue).to.equal('foo');
+        expect(comboBox.value).to.equal('foo');
+      });
+
+      it('should not apply input value on enter if input invalid', () => {
+        inputText('quux');
+        enter();
+        expect(comboBox._inputElementValue).to.equal('quux');
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should revert input value on focusout if input invalid', () => {
+        inputText('quux');
+        comboBox.dispatchEvent(new Event('focusout'));
+        expect(comboBox._inputElementValue).to.equal('');
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should revert input value on esc if input valid', () => {
+        inputText('foo');
+        esc();
+        expect(comboBox._inputElementValue).to.equal('');
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should revert input value on esc if input invalid', () => {
+        inputText('quux');
+        esc();
+        expect(comboBox._inputElementValue).to.equal('');
+        expect(comboBox.value).to.equal('');
+      });
+
     });
   });
 </script>

--- a/test/toggling-dropdown.html
+++ b/test/toggling-dropdown.html
@@ -67,6 +67,13 @@
         expect(combobox.opened).to.be.true;
       });
 
+      it('should not open synchronously by clicking label when autoOpenDisabled is true', () => {
+        combobox.autoOpenDisabled = true;
+        expect(combobox.opened).to.be.false;
+        fireMousedownMouseupClick(combobox.inputElement.root.querySelector('label'));
+        expect(combobox.opened).to.be.false;
+      });
+
       it('should restore attribute focus-ring if it was initially set before opening and combo-box is focused', () => {
         combobox.setAttribute('focus-ring', '');
         combobox.opened = true;
@@ -80,7 +87,24 @@
         expect(combobox.opened).to.be.true;
       });
 
+      it('should not open synchronously by clicking input when autoOpenDisabled is true', () => {
+        combobox.autoOpenDisabled = true;
+        expect(combobox.opened).to.be.false;
+        fireMousedownMouseupClick(combobox.inputElement);
+        expect(combobox.opened).to.be.false;
+      });
+
       it('should open by clicking icon', () => {
+        clickToggleIcon();
+
+        expect(combobox.opened).to.be.true;
+      });
+
+      it('should open by clicking icon when autoOpenDisabled is true and input is invalid', () => {
+        combobox.autoOpenDisabled = true;
+        combobox.inputElement.value = 3;
+        combobox.inputElement.dispatchEvent(new CustomEvent('input'));
+
         clickToggleIcon();
 
         expect(combobox.opened).to.be.true;


### PR DESCRIPTION
When `comboBox.autoOpenDisabled = true`:
- Focusing and typing in field doesn’t open the overlay
- Clicking on icon opens the overlay
- Up / Down keys opens the overlay

Closes #863