### PR TITLE
fix: TS fixes based on findings [skip ci]

### DIFF
--- a/@types/interfaces.d.ts
+++ b/@types/interfaces.d.ts
@@ -1,20 +1,20 @@
 import { ComboBoxElement } from '../src/vaadin-combo-box.js';
 
-export type ComboBoxItem = string | { [key: string]: unknown };
+export type ComboBoxItem = { [key: string]: unknown };
 
-export interface ComboBoxRendererModel {
+export interface ComboBoxItemModel {
   index: number;
-  item: ComboBoxItem;
+  item: ComboBoxItem | string;
 }
 
 export type ComboBoxRenderer = (
   root: HTMLElement,
   comboBox: ComboBoxElement,
-  model: ComboBoxRendererModel
+  model: ComboBoxItemModel
 ) => void;
 
 export type ComboBoxDataProviderCallback = (
-  items: Array<ComboBoxItem>,
+  items: Array<ComboBoxItem | string>,
   size: number
 ) => void;
 

--- a/gen-tsd.json
+++ b/gen-tsd.json
@@ -16,7 +16,7 @@
     ],
     "./@types/interfaces": [
       "ComboBoxItem",
-      "ComboBoxRendererModel",
+      "ComboBoxItemModel",
       "ComboBoxRenderer",
       "ComboBoxDataProvider"
     ]

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -78,7 +78,7 @@ This program is available under Apache License Version 2.0, available at https:/
         /**
          * A full set of items to filter the visible options from.
          * The items can be of either `String` or `Object` type.
-         * @type {!Array<!ComboBoxItem> | undefined}
+         * @type {!Array<!ComboBoxItem | string> | undefined}
          */
         items: {
           type: Array,
@@ -101,7 +101,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * A subset of items, filtered based on the user input. Filtered items
          * can be assigned directly to omit the internal filtering functionality.
          * The items can be of either `String` or `Object` type.
-         * @type {!Array<!ComboBoxItem> | undefined}
+         * @type {!Array<!ComboBoxItem | string> | undefined}
          */
         filteredItems: {
           type: Array
@@ -161,7 +161,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * The selected item from the `items` array.
-         * @type {ComboBoxItem | undefined}
+         * @type {ComboBoxItem | string | undefined}
          */
         selectedItem: {
           type: Object,


### PR DESCRIPTION
Fixes #889 

There is another change in this PR: use `string | ComboBoxItem`, so the following is possible:

```ts
_itemRenderer(root: HTMLElement, owner: ComboBoxElement, model: ComboBoxItemModel) {
  // Cast model.item to access fields. A better way would be "typeof" guard
  const user = model.item as ComboBoxItem;
  root.innerHTML = `<i>${user.firstName} ${user.lastName}</i>`;
}
```

Currently, this type cast isn't possible and the following error is shown:

```
Property 'firstName' does not exist on type 'ComboBoxItem'.
  Property 'firstName' does not exist on type 'string'.
```