### PR TITLE
docs: add JSDoc for attributes [skip ci]

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -17,6 +17,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Number of items fetched at a time from the dataprovider.
+         * @attr {number} page-size
          * @type {number}
          */
         pageSize: {

--- a/src/vaadin-combo-box-light.html
+++ b/src/vaadin-combo-box-light.html
@@ -96,6 +96,7 @@ This program is available under Apache License Version 2.0, available at https:/
           /**
            * Name of the two-way data-bindable property representing the
            * value of the custom input field.
+           * @attr {string} attr-for-value
            * @type {string}
            */
           attrForValue: {

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -38,6 +38,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
         /**
          * Set true to prevent the overlay from opening automatically.
+         * @attr {boolean} auto-open-disabled
          */
         autoOpenDisabled: Boolean,
 
@@ -90,6 +91,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * `value` property will be set to the input value in this case.
          * Also, when `value` is set programmatically, the input value will be set
          * to reflect that value.
+         * @attr {boolean} allow-custom-value
          * @type {boolean}
          */
         allowCustomValue: {
@@ -178,6 +180,7 @@ This program is available under Apache License Version 2.0, available at https:/
          *
          * When using item templates, the property is still needed because it is used
          * for filtering, and for displaying the selected item value in the input box.
+         * @attr {string} item-label-path
          * @type {string}
          */
         itemLabelPath: {
@@ -193,6 +196,7 @@ This program is available under Apache License Version 2.0, available at https:/
          *
          * The item value is used in the `value` property of the combo box,
          * to provide the form value.
+         * @attr {string} item-value-path
          * @type {string}
          */
         itemValuePath: {
@@ -205,6 +209,7 @@ This program is available under Apache License Version 2.0, available at https:/
          * the `itemIdPath` is used to compare and identify the same item
          * in `selectedItem` and `filteredItems` (items given by the
          * `dataProvider` callback).
+         * @attr {string} item-id-path
          */
         itemIdPath: String,
 

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -296,6 +296,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to prevent the user from entering invalid input.
+             * @attr {boolean} prevent-invalid-input
              */
             preventInvalidInput: {
               type: Boolean
@@ -310,6 +311,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * The error message to display when the input is invalid.
+             * @attr {string} error-message
              */
             errorMessage: {
               type: String
@@ -337,6 +339,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
             /**
              * Set to true to display the clear icon which clears the input.
+             * @attr {boolean} clear-button-visible
              * @type {boolean}
              */
             clearButtonVisible: {


### PR DESCRIPTION
Fixes #896 

Note, this is a PR for `5.3` branch. When cherry-picking it to master, we would need to add attribute for `helperText`.