### PR TITLE
fix: mouse scroll doesn't fetch new items

### DIFF
--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -211,6 +211,10 @@ This program is available under Apache License Version 2.0, available at https:/
         filteredItems[i] = filteredItems[i] !== undefined ? filteredItems[i] : this.__placeHolder;
       }
       this.filteredItems = filteredItems;
+
+      // Cleans up the redundant pending requests for pages > size
+      // Refers to https://github.com/vaadin/vaadin-flow-components/issues/229
+      this._flushPendingRequests(size);
     }
 
     /** @private */
@@ -253,6 +257,32 @@ This program is available under Apache License Version 2.0, available at https:/
             'instead of `value`'
           );
           /* eslint-enable no-console */
+        }
+      }
+    }
+
+    /**
+     * This method cleans up the page callbacks which refers to the
+     * non-existing pages, i.e. which item indexes are greater than the
+     * changed size.
+     * This case is basically happens when:
+     * 1. Users scroll fast to the bottom and combo box generates the
+     * redundant page request/callback
+     * 2. Server side uses undefined size lazy loading and suddenly reaches
+     * the exact size which is on the range edge
+     * (for default page size = 50, it will be 100, 200, 300, ...).
+     * @param size the new size of items
+     * @private
+     */
+    _flushPendingRequests(size) {
+      if (this._pendingRequests) {
+        const lastPage = Math.ceil(size / this.pageSize);
+        const pendingRequestsKeys = Object.keys(this._pendingRequests);
+        for (let reqIdx = 0; reqIdx < pendingRequestsKeys.length; reqIdx++) {
+          const page = parseInt(pendingRequestsKeys[reqIdx]);
+          if (page >= lastPage) {
+            this._pendingRequests[page]([], size);
+          }
         }
       }
     }

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -223,7 +223,7 @@ This program is available under Apache License Version 2.0, available at https:/
       _restoreScrollerPosition(items) {
         if (this._isNotEmpty(items) && this._selector && this._oldScrollerPosition !== 0) {
           // new items size might be less than old scrolling position
-          this._selector.scrollToIndex(Math.min(items.length - 1, this._oldScrollerPosition));
+          this._scrollIntoView(Math.min(items.length - 1, this._oldScrollerPosition));
           this.resetScrolling = false;
           // reset position to 0 again in order to properly handle the filter
           // cases (scroll to 0 after typing the filter)

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -459,6 +459,57 @@
             comboBox.size = 1;
             expect(comboBox.filteredItems).to.eql(['foo']);
           });
+
+          it('should not show the loading on size change while pending the data provider', () => {
+            const allItems = Array(...new Array(200)).map((_, i) => `item ${i}`);
+
+            comboBox.size = 200;
+            comboBox.dataProvider = (params, callback) => {
+              if (params.page > 1) {
+                // Pending the page = 2...
+                return;
+              }
+              const offset = params.page * params.pageSize;
+              const slice = allItems.slice(offset, offset + params.pageSize);
+              callback(slice, allItems.length);
+            };
+            comboBox.open();
+            expect(comboBox.loading).to.be.false;
+            comboBox.$.overlay._scrollIntoView(45);
+            expect(comboBox.loading).to.be.false;
+            comboBox.$.overlay._scrollIntoView(150);
+            // Fetching the page = 2 and stucking
+            expect(comboBox.loading).to.be.true;
+            // Updating the size means we don't need pending requests anymore,
+            // and combo box should show no loading
+            comboBox.size = 100;
+            expect(comboBox.loading).to.be.false;
+          });
+
+          it('should not show the loading on fast scrolling and size update', () => {
+            const ITEMS_SIZE = 1000;
+            const allItems = Array(...new Array(ITEMS_SIZE)).map((_, i) => `item ${i}`);
+
+            comboBox.size = ITEMS_SIZE;
+            comboBox.dataProvider = (params, callback) => {
+              // Response for the first page immediately
+              if (params.page === 0) {
+                const offset = params.page * params.pageSize;
+                const slice = allItems.slice(offset, offset + params.pageSize);
+                callback(slice, allItems.length);
+              }
+              // ...and postpone the response for rest of the pages, in order to
+              // have them stuck in the pending queue
+            };
+            comboBox.open();
+            // Scroll fast to a large page
+            comboBox.$.overlay._scrollIntoView(400);
+            expect(comboBox.loading).to.be.true;
+            // Reduce the size and trigger pending queue cleanup
+            comboBox.size = 50;
+            expect(comboBox.loading).to.be.false;
+          });
+
         });
 
         /* eslint-disable no-console */
@@ -843,6 +894,44 @@
             comboBox.filter = '1';
             expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.equal(0);
           });
+
+          it('should not show the loading when exact size is suddenly reached in the middle of requested range', () => {
+            const REAL_SIZE = 294;
+            const ESTIMATED_SIZE = 400;
+
+            const allItems = Array(...new Array(REAL_SIZE)).map((_, i) => `item ${i}`);
+            let lastPageAlreadyRequested = false;
+
+            comboBox.size = ESTIMATED_SIZE;
+
+            // Simulates a combo-box server side data provider specifics with
+            // undefined size
+            comboBox.dataProvider = (params, callback) => {
+              const offset = params.page * params.pageSize;
+              const slice = allItems.slice(offset, offset + params.pageSize);
+
+              // Combo box server side always notifies about size change
+              comboBox.size = params.page < 5 ? ESTIMATED_SIZE : REAL_SIZE;
+
+              if (params.page < 5) {
+                callback(slice, ESTIMATED_SIZE);
+              } else if (params.page === 5) {
+                // Combo box server side does not update the client with the
+                // items which were sent recently
+                if (!lastPageAlreadyRequested) {
+                  callback(slice, REAL_SIZE);
+                  lastPageAlreadyRequested = true;
+                }
+              }
+            };
+            comboBox.open();
+            // Scroll to last page and verify there is no loading indicator and
+            // the last page has been fetched and rendered
+            comboBox.$.overlay._scrollIntoView(274);
+            expect(comboBox.loading).to.be.false;
+            expect(comboBox.filteredItems).to.contain('item 293');
+          });
+
         });
       };
 

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -884,7 +884,7 @@
             comboBox.size = 300;
             // verify whether the scroller not jumped to 0 pos and restored
             // approx between 1 and 2 page (exact value may vary depending of window size)
-            expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.greaterThan(comboBox.pageSize).and.lessThan(comboBox.pageSize * 2);
+            expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.greaterThan(comboBox.pageSize - 1).and.lessThan(comboBox.pageSize * 2);
           });
 
           it('should reset to 0 when filter applied and filtered items size more than page size', () => {

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -878,13 +878,20 @@
           const allItems = Array(...new Array(ESTIMATED_SIZE)).map((_, i) => `item ${i}`);
 
           it('should restore the scroll position after size update', () => {
+            const targetItemIndex = 75;
             comboBox.dataProvider = getDataProvider(allItems);
             comboBox.opened = true;
-            comboBox.$.overlay._scrollIntoView(75);
+            comboBox.$.overlay._scrollIntoView(targetItemIndex);
             comboBox.size = 300;
-            // verify whether the scroller not jumped to 0 pos and restored
-            // approx between 1 and 2 page (exact value may vary depending of window size)
-            expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.greaterThan(comboBox.pageSize - 1).and.lessThan(comboBox.pageSize * 2);
+            // verify whether the scroller not jumped to 0 pos and restored properly,
+            // having the item with 'targetItemIndex' in the bottom
+            // (exact visible items may vary depending of window size),
+            // and sometimes the 'ironList.scrollToIndex' does not point
+            // precisely to the given index, so use some margin
+            const scrollMargin = 5;
+            const expectedFirstVisibleIndex = targetItemIndex - comboBox.$.overlay._visibleItemsCount() - scrollMargin;
+            expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.greaterThan(expectedFirstVisibleIndex);
+            expect(comboBox.$.overlay._selector.lastVisibleIndex).to.be.lessThan(targetItemIndex + 1);
           });
 
           it('should reset to 0 when filter applied and filtered items size more than page size', () => {

--- a/test/lazy-loading.html
+++ b/test/lazy-loading.html
@@ -902,6 +902,51 @@
             expect(comboBox.$.overlay._selector.firstVisibleIndex).to.be.equal(0);
           });
 
+          // Verifies https://github.com/vaadin/vaadin-combo-box/issues/957
+          it('should fetch the items after scrolling to the bottom with scrollbar', done => {
+            const REAL_SIZE = 1234;
+            let ESTIMATED_SIZE = 200;
+            const allItems = Array(...new Array(REAL_SIZE)).map((_, i) => `item ${i}`);
+
+            // DataProvider for unknown size lazy loading
+            const getDataProvider = (allItems) => (params, callback) => {
+              const filteredItems = allItems.filter(item => item.indexOf(params.filter) > -1);
+              const offset = params.page * params.pageSize;
+              const end = offset + params.pageSize;
+
+              dataProviderItems = filteredItems.slice(offset, end);
+
+              if (dataProviderItems.size === 0) {
+                ESTIMATED_SIZE = offset;
+              } else if (dataProviderItems.size < params.pageSize) {
+                ESTIMATED_SIZE = offset + dataProviderItems.size;
+              } else if (end > ESTIMATED_SIZE - params.pageSize) {
+                ESTIMATED_SIZE += 200;
+              }
+              callback(dataProviderItems, ESTIMATED_SIZE);
+            };
+
+            comboBox.dataProvider = getDataProvider(allItems);
+            comboBox.opened = true;
+            Polymer.flush();
+
+            // Scroll to the end, as though if we drag the scrollbar and move it
+            // to the bottom
+            const scrollHeight = comboBox.$.overlay._selector._scrollHeight;
+            comboBox.$.overlay._scroller.scrollTop += scrollHeight;
+
+            // Flush the pending changes after the scrolling
+            flush(() => {
+              const lastVisibleIndex = comboBox.$.overlay._selector.lastVisibleIndex;
+              // Check if the next few items after the last visible item are not empty
+              for (let nextIndexIncrement = 0; nextIndexIncrement < 5; nextIndexIncrement++) {
+                const lastItem = comboBox.filteredItems[lastVisibleIndex + nextIndexIncrement];
+                expect(lastItem instanceof Vaadin.ComboBoxPlaceholder).is.false;
+              }
+              done();
+            });
+          });
+
           it('should not show the loading when exact size is suddenly reached in the middle of requested range', () => {
             const REAL_SIZE = 294;
             const ESTIMATED_SIZE = 400;


### PR DESCRIPTION
The function `_scrollIntoView(index)` is used instead of `scrollToIndex(index)` to provide more accurate scroll while restoring the old position in unknown size lazy loading, and ensure the next page after target index is also loaded and rendered.
 
Fixes https://github.com/vaadin/vaadin-combo-box/issues/957