### PR TITLE
Support clearing the items property

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -901,11 +901,13 @@ This program is available under Apache License Version 2.0, available at https:/
 
     /** @private */
     _itemsOrPathsChanged(e, itemValuePath, itemLabelPath) {
-      if (e.value === undefined) {
-        return;
-      }
       if (e.path === 'items' || e.path === 'items.splices') {
-        this.filteredItems = this.items ? this.items.slice(0) : this.items;
+        if (this.items) {
+          this.filteredItems = this.items.slice(0);
+        } else if (this.__previousItems) {
+          // Only clear filteredItems if the component had items previously but got cleared
+          this.filteredItems = null;
+        }
 
         const valueIndex = this._indexOfValue(this.value, this.items);
         this._focusedIndex = valueIndex;
@@ -915,13 +917,11 @@ This program is available under Apache License Version 2.0, available at https:/
           this.selectedItem = item;
         }
       }
+      this.__previousItems = e.value;
     }
 
     /** @private */
     _filteredItemsChanged(e, itemValuePath, itemLabelPath) {
-      if (e.value === undefined) {
-        return;
-      }
       if (e.path === 'filteredItems' || e.path === 'filteredItems.splices') {
         this._setOverlayItems(this.filteredItems);
 

--- a/test/filtering.html
+++ b/test/filtering.html
@@ -274,10 +274,8 @@
 
     describe('external filtering', () => {
       beforeEach(() => {
-        comboBox.setProperties({
-          filteredItems: ['foo', 'bar', 'baz'],
-          items: undefined
-        });
+        comboBox.items = undefined;
+        comboBox.filteredItems = ['foo', 'bar', 'baz'];
       });
 
       it('should set items to filteredItems', () => {

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -118,6 +118,13 @@
 
           expect(comboBox._focusedIndex).to.eql(2);
         });
+
+        it('should support resetting items', () => {
+          comboBox.items = ['foo', 'bar'];
+          comboBox.items = undefined;
+          comboBox.opened = true;
+          expect(comboBox.$.overlay._selector._virtualCount).to.eql(0);
+        });
       });
 
       describe('value property', () => {


### PR DESCRIPTION
FIxes #973 

Note that if the combo box already has a selected value, the `value` will not be cleared when `items` is set `undefined`. This is also the current behavior when new `items` is assigned and it doesn't contain the selected value.