### PR TITLE
fix: Scrolling quickly to the bottom shows blank items

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 dist: xenial
 language: node_js
-node_js: 8.11
+node_js: 10.23
 
 cache:
   directories:

--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -190,6 +190,10 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }
         };
+        if (this._pendingRequests[page]) {
+          // Resolve any pending requests for the same page
+          this._pendingRequests[page]([]);
+        }
         this._pendingRequests[page] = callback;
         this.dataProvider(params, callback);
       }

--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -99,7 +99,10 @@ This program is available under Apache License Version 2.0, available at https:/
         const currentScrollerPos = e.detail.currentScrollerPos;
         const allowedIndexRange = Math.floor(this.pageSize * 1.5);
 
-        // Avoid double loading of last page we scroll to
+        // Ignores the indexes, which are being re-sent during scrolling reset,
+        // if the corresponding page is around the current scroller position.
+        // Otherwise, there might be a last pages duplicates, which cause the
+        // loading indicator hanging and blank items
         if (this._shouldSkipIndex(index, allowedIndexRange, currentScrollerPos)) {
           return;
         }

--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -96,6 +96,14 @@ This program is available under Apache License Version 2.0, available at https:/
       this.clearCache();
       this.$.overlay.addEventListener('index-requested', e => {
         const index = e.detail.index;
+        const currentScrollerPos = e.detail.currentScrollerPos;
+        const allowedIndexRange = Math.floor(this.pageSize * 1.5);
+
+        // Avoid double loading of last page we scroll to
+        if (this._shouldSkipIndex(index, allowedIndexRange, currentScrollerPos)) {
+          return;
+        }
+
         if (index !== undefined) {
           const page = this._getPageForIndex(index);
           if (this._shouldLoadPage(page)) {
@@ -132,6 +140,13 @@ This program is available under Apache License Version 2.0, available at https:/
       if (opened && this._shouldLoadPage(0)) {
         this._loadPage(0);
       }
+    }
+
+    /** @private */
+    _shouldSkipIndex(index, allowedIndexRange, currentScrollerPos) {
+      return currentScrollerPos !== 0 &&
+          index >= currentScrollerPos - allowedIndexRange &&
+          index <= currentScrollerPos + allowedIndexRange;
     }
 
     /** @private */

--- a/src/vaadin-combo-box-data-provider-mixin.html
+++ b/src/vaadin-combo-box-data-provider-mixin.html
@@ -190,12 +190,13 @@ This program is available under Apache License Version 2.0, available at https:/
             }
           }
         };
-        if (this._pendingRequests[page]) {
-          // Resolve any pending requests for the same page
-          this._pendingRequests[page]([]);
+
+        if (!this._pendingRequests[page]) {
+          // Don't request page if it's already being requested
+          this._pendingRequests[page] = callback;
+          this.dataProvider(params, callback);
         }
-        this._pendingRequests[page] = callback;
-        this.dataProvider(params, callback);
+
       }
     }
 

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -39,7 +39,7 @@ This program is available under Apache License Version 2.0, available at https:/
             <template>
               <vaadin-combo-box-item
                 on-click="_onItemClick"
-                index="[[__requestItemByIndex(item, index, resetScrolling)]]"
+                index="[[__requestItemByIndex(item, index, _resetScrolling)]]"
                 item="[[item]]"
                 label="[[getItemLabel(item, _itemLabelPath)]]"
                 selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"
@@ -123,21 +123,21 @@ This program is available under Apache License Version 2.0, available at https:/
           theme: String,
 
           /**
-           * Used to recognize scroller reset after new items have been set
-           * to iron-list and to ignore unwanted pages load. If 'true', then
-           * skip loading of the pages until it becomes 'false'.
-           */
-          resetScrolling: {
-            type: Boolean,
-            value: false
-          },
-
-          /**
            * Used to recognize if the filter changed, so to skip the
            * scrolling restore. If true, then scroll to 0 position. Restore
            * the previous position otherwise.
            */
           filterChanged: {
+            type: Boolean,
+            value: false
+          },
+
+          /**
+           * Used to recognize scroller reset after new items have been set
+           * to iron-list and to ignore unwanted pages load. If 'true', then
+           * skip loading of the pages until it becomes 'false'.
+           */
+          _resetScrolling: {
             type: Boolean,
             value: false
           },
@@ -209,7 +209,7 @@ This program is available under Apache License Version 2.0, available at https:/
             const currentScrollerPosition = this._selector.firstVisibleIndex;
             if (currentScrollerPosition !== 0) {
               this._oldScrollerPosition = currentScrollerPosition;
-              this.resetScrolling = true;
+              this._resetScrolling = true;
             }
           }
           // Let the position to be restored in the future calls unless it's not
@@ -224,7 +224,7 @@ This program is available under Apache License Version 2.0, available at https:/
         if (this._isNotEmpty(items) && this._selector && this._oldScrollerPosition !== 0) {
           // new items size might be less than old scrolling position
           this._scrollIntoView(Math.min(items.length - 1, this._oldScrollerPosition));
-          this.resetScrolling = false;
+          this._resetScrolling = false;
           // reset position to 0 again in order to properly handle the filter
           // cases (scroll to 0 after typing the filter)
           this._oldScrollerPosition = 0;
@@ -379,10 +379,11 @@ This program is available under Apache License Version 2.0, available at https:/
        *
        * @return {number}
        */
-      __requestItemByIndex(item, index) {
+      __requestItemByIndex(item, index, resetScrolling) {
         if ((item instanceof Vaadin.ComboBoxPlaceholder) && index !==
-                undefined && !this.resetScrolling) {
-          this.dispatchEvent(new CustomEvent('index-requested', {detail: {index}}));
+                undefined && !resetScrolling) {
+          this.dispatchEvent(new CustomEvent('index-requested', {detail:
+                    {index: index, currentScrollerPos: this._oldScrollerPosition}}));
         }
 
         return index;

--- a/src/vaadin-combo-box-dropdown-wrapper.html
+++ b/src/vaadin-combo-box-dropdown-wrapper.html
@@ -39,7 +39,7 @@ This program is available under Apache License Version 2.0, available at https:/
             <template>
               <vaadin-combo-box-item
                 on-click="_onItemClick"
-                index="[[__requestItemByIndex(item, index)]]"
+                index="[[__requestItemByIndex(item, index, resetScrolling)]]"
                 item="[[item]]"
                 label="[[getItemLabel(item, _itemLabelPath)]]"
                 selected="[[_isItemSelected(item, _selectedItem, _itemIdPath)]]"


### PR DESCRIPTION
When the dropdown was being scrolled quickly, some pages weren't being loaded and skipped in the end. It's fixed by resending the skipped pages after the scroller reset and filter those indexes which are close to current scroller position, so as to avoid unnecessary duplicated pages and loading indicator hanging.

Fixes: https://github.com/vaadin/vaadin-combo-box/issues/970

In draft still, because need to cover these changes by a tests.