### PR TITLE
chore: update JSDoc for custom events [skip ci]

### DIFF
--- a/src/vaadin-combo-box-light.js
+++ b/src/vaadin-combo-box-light.js
@@ -53,11 +53,11 @@ import './vaadin-combo-box-dropdown-wrapper.js';
  * </vaadin-combo-box-light>
  * ```
  *
- * @fires {CustomEvent<string>} filter-changed
- * @fires {CustomEvent<boolean>} invalid-changed
- * @fires {CustomEvent<boolean>} opened-change
- * @fires {CustomEvent<unknown>} selected-item-changed
- * @fires {CustomEvent<string>} value-changed
+ * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  *
  * @extends HTMLElement
  * @mixes ComboBoxDataProviderMixin

--- a/src/vaadin-combo-box.d.ts
+++ b/src/vaadin-combo-box.d.ts
@@ -165,11 +165,11 @@ import { ComboBoxEventMap } from './interfaces';
  *
  * See [ThemableMixin – how to apply styles for shadow parts](https://github.com/vaadin/vaadin-themable-mixin/wiki)
  *
- * @fires {CustomEvent<string>} filter-changed
- * @fires {CustomEvent<boolean>} invalid-changed
- * @fires {CustomEvent<boolean>} opened-change
- * @fires {CustomEvent<unknown>} selected-item-changed
- * @fires {CustomEvent<string>} value-changed
+ * @fires {CustomEvent} filter-changed - Fired when the `filter` property changes.
+ * @fires {CustomEvent} invalid-changed - Fired when the `invalid` property changes.
+ * @fires {CustomEvent} opened-changed - Fired when the `opened` property changes.
+ * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
+ * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
 declare class ComboBoxElement extends ElementMixin(
   ControlStateMixin(ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))))


### PR DESCRIPTION
1. Fixed a typo: `opened-change` -> `opened-changed`.
2. Added events descriptions to `@fires` annotations
3. Removed event types as they are not picked up by TS.