### PR TITLE
refactor: remove ShadyCSS workarounds

### DIFF
--- a/theme/lumo/vaadin-combo-box-item-styles.js
+++ b/theme/lumo/vaadin-combo-box-item-styles.js
@@ -19,11 +19,6 @@ registerStyles(
       --_lumo-item-selected-icon-display: block;
     }
 
-    /* ShadyCSS workaround (show the selected item checkmark) */
-    :host::before {
-      display: block;
-    }
-
     :host(:hover) {
       background-color: var(--lumo-primary-color-10pct);
     }

--- a/theme/material/vaadin-combo-box-item-styles.js
+++ b/theme/material/vaadin-combo-box-item-styles.js
@@ -16,11 +16,6 @@ registerStyles(
       --_material-item-selected-icon-display: block;
     }
 
-    /* ShadyCSS workaround */
-    :host::before {
-      display: block;
-    }
-
     :host(:hover) {
       background-color: var(--material-secondary-background-color);
     }


### PR DESCRIPTION
We no longer support IE11 which required this to work properly, so let's remove these workarounds.