### PR TITLE
feat!: support generics for item type

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,20 +1,18 @@
 import { ComboBoxElement } from '../src/vaadin-combo-box.js';
 
-export type ComboBoxItem = unknown;
-
-export interface ComboBoxItemModel {
+export interface ComboBoxItemModel<T> {
   index: number;
-  item: ComboBoxItem | string;
+  item: T;
 }
 
-export type ComboBoxRenderer = (
+export type ComboBoxRenderer<T> = (
   root: HTMLElement,
-  comboBox: ComboBoxElement,
-  model: ComboBoxItemModel
+  comboBox: ComboBoxElement<T>,
+  model: ComboBoxItemModel<T>
 ) => void;
 
-export type ComboBoxDataProviderCallback = (
-  items: Array<ComboBoxItem | string>,
+export type ComboBoxDataProviderCallback<T> = (
+  items: Array<T>,
   size: number
 ) => void;
 
@@ -24,9 +22,9 @@ export interface ComboBoxDataProviderParams {
   filter: string;
 }
 
-export type ComboBoxDataProvider = (
+export type ComboBoxDataProvider<T> = (
   params: ComboBoxDataProviderParams,
-  callback: ComboBoxDataProviderCallback
+  callback: ComboBoxDataProviderCallback<T>
 ) => void;
 
 /**
@@ -54,7 +52,7 @@ export type ComboBoxFilterChanged = CustomEvent<{ value: string }>;
  */
 export type ComboBoxSelectedItemChanged<T> = CustomEvent<{ value: T }>;
 
-export interface ComboBoxElementEventMap {
+export interface ComboBoxElementEventMap<T> {
   'opened-changed': ComboBoxOpenedChanged;
 
   'filter-changed': ComboBoxFilterChanged;
@@ -63,7 +61,7 @@ export interface ComboBoxElementEventMap {
 
   'value-changed': ComboBoxValueChanged;
 
-  'selected-item-changed': ComboBoxSelectedItemChanged<any>;
+  'selected-item-changed': ComboBoxSelectedItemChanged<T>;
 }
 
-export interface ComboBoxEventMap extends HTMLElementEventMap, ComboBoxElementEventMap {}
+export type ComboBoxEventMap<T> = HTMLElementEventMap & ComboBoxElementEventMap<T>;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -1,20 +1,11 @@
-import { ComboBoxElement } from '../src/vaadin-combo-box.js';
-
 export interface ComboBoxItemModel<T> {
   index: number;
   item: T;
 }
 
-export type ComboBoxRenderer<T> = (
-  root: HTMLElement,
-  comboBox: ComboBoxElement<T>,
-  model: ComboBoxItemModel<T>
-) => void;
+export type ComboBoxRenderer<T> = (root: HTMLElement, comboBox: HTMLElement, model: ComboBoxItemModel<T>) => void;
 
-export type ComboBoxDataProviderCallback<T> = (
-  items: Array<T>,
-  size: number
-) => void;
+export type ComboBoxDataProviderCallback<T> = (items: Array<T>, size: number) => void;
 
 export interface ComboBoxDataProviderParams {
   page: number;

--- a/src/vaadin-combo-box-data-provider-mixin.d.ts
+++ b/src/vaadin-combo-box-data-provider-mixin.d.ts
@@ -33,7 +33,7 @@ interface ComboBoxDataProviderMixin {
    *   - `items` Current page of items
    *   - `size` Total number of items.
    */
-  dataProvider: ComboBoxDataProvider | null | undefined;
+  dataProvider: ComboBoxDataProvider<unknown> | null | undefined;
 
   /**
    * Clears the cached pages and reloads data from dataprovider when needed.

--- a/src/vaadin-combo-box-light.d.ts
+++ b/src/vaadin-combo-box-light.d.ts
@@ -132,7 +132,7 @@ declare class ComboBoxLightElement<Item> extends ComboBoxDataProviderMixin(Combo
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box-light': ComboBoxLightElement<any>;
+    'vaadin-combo-box-light': ComboBoxLightElement<unknown>;
   }
 }
 

--- a/src/vaadin-combo-box-light.d.ts
+++ b/src/vaadin-combo-box-light.d.ts
@@ -4,7 +4,7 @@ import { ComboBoxMixin } from './vaadin-combo-box-mixin.js';
 
 import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixin.js';
 
-import { ComboBoxEventMap } from './interfaces';
+import { ComboBoxDataProvider, ComboBoxEventMap, ComboBoxRenderer } from './interfaces';
 
 /**
  * `<vaadin-combo-box-light>` is a customizable version of the `<vaadin-combo-box>` providing
@@ -55,7 +55,53 @@ import { ComboBoxEventMap } from './interfaces';
  * @fires {CustomEvent<unknown>} selected-item-changed
  * @fires {CustomEvent<string>} value-changed
  */
-declare class ComboBoxLightElement extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))) {
+declare class ComboBoxLightElement<Item> extends ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))) {
+  /**
+   * Function that provides items lazily. Receives arguments `params`, `callback`
+   *
+   * `params.page` Requested page index
+   *
+   * `params.pageSize` Current page size
+   *
+   * `params.filter` Currently applied filter
+   *
+   * `callback(items, size)` Callback function with arguments:
+   *   - `items` Current page of items
+   *   - `size` Total number of items.
+   */
+  dataProvider: ComboBoxDataProvider<Item> | null | undefined;
+
+  /**
+   * Custom function for rendering the content of every item.
+   * Receives three arguments:
+   *
+   * - `root` The `<vaadin-combo-box-item>` internal container DOM element.
+   * - `comboBox` The reference to the `<vaadin-combo-box>` element.
+   * - `model` The object with the properties related with the rendered
+   *   item, contains:
+   *   - `model.index` The index of the rendered item.
+   *   - `model.item` The item.
+   */
+  renderer: ComboBoxRenderer<Item> | null | undefined;
+
+  /**
+   * A full set of items to filter the visible options from.
+   * The items can be of either `String` or `Object` type.
+   */
+  items: Array<Item> | undefined;
+
+  /**
+   * A subset of items, filtered based on the user input. Filtered items
+   * can be assigned directly to omit the internal filtering functionality.
+   * The items can be of either `String` or `Object` type.
+   */
+  filteredItems: Array<Item> | undefined;
+
+  /**
+   * The selected item from the `items` array.
+   */
+  selectedItem: Item | null | undefined;
+
   readonly _propertyForValue: string;
 
   _inputElementValue: string;
@@ -71,22 +117,22 @@ declare class ComboBoxLightElement extends ComboBoxDataProviderMixin(ComboBoxMix
 
   readonly inputElement: Element | undefined;
 
-  addEventListener<K extends keyof ComboBoxEventMap>(
+  addEventListener<K extends keyof ComboBoxEventMap<Item>>(
     type: K,
-    listener: (this: ComboBoxLightElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxLightElement<Item>, ev: ComboBoxEventMap<Item>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof ComboBoxEventMap>(
+  removeEventListener<K extends keyof ComboBoxEventMap<Item>>(
     type: K,
-    listener: (this: ComboBoxLightElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxLightElement<Item>, ev: ComboBoxEventMap<Item>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box-light': ComboBoxLightElement;
+    'vaadin-combo-box-light': ComboBoxLightElement<any>;
   }
 }
 

--- a/src/vaadin-combo-box-mixin.d.ts
+++ b/src/vaadin-combo-box-mixin.d.ts
@@ -1,4 +1,4 @@
-import { ComboBoxItem, ComboBoxRenderer } from './interfaces';
+import { ComboBoxRenderer } from './interfaces';
 
 declare function ComboBoxMixin<T extends new (...args: any[]) => {}>(base: T): T & ComboBoxMixinConstructor;
 
@@ -41,13 +41,13 @@ interface ComboBoxMixin {
    *   - `model.index` The index of the rendered item.
    *   - `model.item` The item.
    */
-  renderer: ComboBoxRenderer | null | undefined;
+  renderer: ComboBoxRenderer<any> | null | undefined;
 
   /**
    * A full set of items to filter the visible options from.
    * The items can be of either `String` or `Object` type.
    */
-  items: Array<ComboBoxItem | string> | undefined;
+  items: Array<unknown> | undefined;
 
   /**
    * If `true`, the user can input a value that is not present in the items list.
@@ -63,7 +63,7 @@ interface ComboBoxMixin {
    * can be assigned directly to omit the internal filtering functionality.
    * The items can be of either `String` or `Object` type.
    */
-  filteredItems: Array<ComboBoxItem | string> | undefined;
+  filteredItems: Array<unknown> | undefined;
 
   /**
    * The `String` value for the selected item of the combo box.
@@ -90,7 +90,7 @@ interface ComboBoxMixin {
   /**
    * The selected item from the `items` array.
    */
-  selectedItem: ComboBoxItem | string | null | undefined;
+  selectedItem: unknown | null | undefined;
 
   /**
    * Path for label of the item. If `items` is an array of objects, the

--- a/src/vaadin-combo-box-mixin.d.ts
+++ b/src/vaadin-combo-box-mixin.d.ts
@@ -3,10 +3,12 @@ import { ComboBoxRenderer } from './interfaces';
 declare function ComboBoxMixin<T extends new (...args: any[]) => {}>(base: T): T & ComboBoxMixinConstructor;
 
 interface ComboBoxMixinConstructor {
-  new (...args: any[]): ComboBoxMixin;
+  // Use `any` instead of `unknown` to avoid TS error:
+  // Type 'unknown' is not assignable to type 'Item'.
+  new (...args: any[]): ComboBoxMixin<any>;
 }
 
-interface ComboBoxMixin {
+interface ComboBoxMixin<T> {
   readonly _propertyForValue: string;
 
   /**
@@ -41,7 +43,7 @@ interface ComboBoxMixin {
    *   - `model.index` The index of the rendered item.
    *   - `model.item` The item.
    */
-  renderer: ComboBoxRenderer<any> | null | undefined;
+  renderer: ComboBoxRenderer<T> | null | undefined;
 
   /**
    * A full set of items to filter the visible options from.

--- a/src/vaadin-combo-box.d.ts
+++ b/src/vaadin-combo-box.d.ts
@@ -10,7 +10,7 @@ import { ComboBoxDataProviderMixin } from './vaadin-combo-box-data-provider-mixi
 
 import { ElementMixin } from '@vaadin/vaadin-element-mixin/vaadin-element-mixin.js';
 
-import { ComboBoxEventMap } from './interfaces';
+import { ComboBoxDataProvider, ComboBoxEventMap, ComboBoxRenderer } from './interfaces';
 
 /**
  * `<vaadin-combo-box>` is a combo box element combining a dropdown list with an
@@ -171,9 +171,55 @@ import { ComboBoxEventMap } from './interfaces';
  * @fires {CustomEvent} selected-item-changed - Fired when the `selectedItem` property changes.
  * @fires {CustomEvent} value-changed - Fired when the `value` property changes.
  */
-declare class ComboBoxElement extends ElementMixin(
+declare class ComboBoxElement<Item> extends ElementMixin(
   ControlStateMixin(ComboBoxDataProviderMixin(ComboBoxMixin(ThemableMixin(HTMLElement))))
 ) {
+  /**
+   * Function that provides items lazily. Receives arguments `params`, `callback`
+   *
+   * `params.page` Requested page index
+   *
+   * `params.pageSize` Current page size
+   *
+   * `params.filter` Currently applied filter
+   *
+   * `callback(items, size)` Callback function with arguments:
+   *   - `items` Current page of items
+   *   - `size` Total number of items.
+   */
+  dataProvider: ComboBoxDataProvider<Item> | null | undefined;
+
+  /**
+   * Custom function for rendering the content of every item.
+   * Receives three arguments:
+   *
+   * - `root` The `<vaadin-combo-box-item>` internal container DOM element.
+   * - `comboBox` The reference to the `<vaadin-combo-box>` element.
+   * - `model` The object with the properties related with the rendered
+   *   item, contains:
+   *   - `model.index` The index of the rendered item.
+   *   - `model.item` The item.
+   */
+  renderer: ComboBoxRenderer<Item> | null | undefined;
+
+  /**
+   * A full set of items to filter the visible options from.
+   * The items can be of either `String` or `Object` type.
+   */
+  items: Array<Item> | undefined;
+
+  /**
+   * A subset of items, filtered based on the user input. Filtered items
+   * can be assigned directly to omit the internal filtering functionality.
+   * The items can be of either `String` or `Object` type.
+   */
+  filteredItems: Array<Item> | undefined;
+
+  /**
+   * The selected item from the `items` array.
+   */
+  selectedItem: Item | null | undefined;
+
   /**
    * Focusable element used by vaadin-control-state-mixin
    */
@@ -237,22 +283,22 @@ declare class ComboBoxElement extends ElementMixin(
    */
   clearButtonVisible: boolean;
 
-  addEventListener<K extends keyof ComboBoxEventMap>(
+  addEventListener<K extends keyof ComboBoxEventMap<Item>>(
     type: K,
-    listener: (this: ComboBoxElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxElement<Item>, ev: ComboBoxEventMap<Item>[K]) => void,
     options?: boolean | AddEventListenerOptions
   ): void;
 
-  removeEventListener<K extends keyof ComboBoxEventMap>(
+  removeEventListener<K extends keyof ComboBoxEventMap<Item>>(
     type: K,
-    listener: (this: ComboBoxElement, ev: ComboBoxEventMap[K]) => void,
+    listener: (this: ComboBoxElement<Item>, ev: ComboBoxEventMap<Item>[K]) => void,
     options?: boolean | EventListenerOptions
   ): void;
 }
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box': ComboBoxElement;
+    'vaadin-combo-box': ComboBoxElement<any>;
   }
 }
 

--- a/src/vaadin-combo-box.d.ts
+++ b/src/vaadin-combo-box.d.ts
@@ -298,7 +298,7 @@ declare class ComboBoxElement<Item> extends ElementMixin(
 
 declare global {
   interface HTMLElementTagNameMap {
-    'vaadin-combo-box': ComboBoxElement<any>;
+    'vaadin-combo-box': ComboBoxElement<unknown>;
   }
 }
 

--- a/test/typings/combo-box.types.ts
+++ b/test/typings/combo-box.types.ts
@@ -1,10 +1,11 @@
-import { ComboBoxSelectedItemChanged } from '../../src/interfaces';
-import '../../src/vaadin-combo-box';
-import '../../src/vaadin-combo-box-light';
+import { ComboBoxElement } from '../../src/vaadin-combo-box';
+import { ComboBoxLightElement } from '../../src/vaadin-combo-box-light';
 
 const assert = <T>(value: T) => value;
 
-const comboBox = document.createElement('vaadin-combo-box');
+type Item = { label: string; value: string };
+
+const comboBox: ComboBoxElement<Item> = document.createElement('vaadin-combo-box');
 
 comboBox.addEventListener('opened-changed', (event) => {
   assert<boolean>(event.detail.value);
@@ -22,14 +23,11 @@ comboBox.addEventListener('filter-changed', (event) => {
   assert<string>(event.detail.value);
 });
 
-comboBox.addEventListener(
-  'selected-item-changed',
-  (event: ComboBoxSelectedItemChanged<{ label: string; value: string }>) => {
-    assert<{ label: string; value: string }>(event.detail.value);
-  }
-);
+comboBox.addEventListener('selected-item-changed', (event) => {
+  assert<Item>(event.detail.value);
+});
 
-const light = document.createElement('vaadin-combo-box-light');
+const light: ComboBoxLightElement<Item> = document.createElement('vaadin-combo-box-light');
 
 light.addEventListener('opened-changed', (event) => {
   assert<boolean>(event.detail.value);
@@ -47,9 +45,6 @@ light.addEventListener('filter-changed', (event) => {
   assert<string>(event.detail.value);
 });
 
-light.addEventListener(
-  'selected-item-changed',
-  (event: ComboBoxSelectedItemChanged<{ label: string; value: string }>) => {
-    assert<{ label: string; value: string }>(event.detail.value);
-  }
-);
+light.addEventListener('selected-item-changed', (event) => {
+  assert<Item>(event.detail.value);
+});

--- a/test/typings/combo-box.types.ts
+++ b/test/typings/combo-box.types.ts
@@ -5,7 +5,7 @@ const assert = <T>(value: T) => value;
 
 type Item = { label: string; value: string };
 
-const comboBox: ComboBoxElement<Item> = document.createElement('vaadin-combo-box');
+const comboBox = document.createElement('vaadin-combo-box') as ComboBoxElement<Item>;
 
 comboBox.addEventListener('opened-changed', (event) => {
   assert<boolean>(event.detail.value);
@@ -27,7 +27,7 @@ comboBox.addEventListener('selected-item-changed', (event) => {
   assert<Item>(event.detail.value);
 });
 
-const light: ComboBoxLightElement<Item> = document.createElement('vaadin-combo-box-light');
+const light = document.createElement('vaadin-combo-box-light') as ComboBoxLightElement<Item>;
 
 light.addEventListener('opened-changed', (event) => {
   assert<boolean>(event.detail.value);


### PR DESCRIPTION
Fixes #985 

This is a breaking change which consists of the following:

1. Removes `ComboBoxItem` which is just an alias for `unknown` and therefore is pretty much useless;
2. Change certain types to use generics using the type cast like this:

```ts
const comboBox = this.shadowRoot.querySelector('vaadin-combo-box') as ComboBoxElement<User>
````

Note, I had to copy-paste and override the related properties on the element classes instead of modifying relevant mixins. 
This is needed because of the TypeScript limitation, see https://github.com/vaadin/vaadin-combo-box/issues/985#issuecomment-749380363 and https://github.com/microsoft/TypeScript/issues/24122.