### PR TITLE
refactor: cleanup dead code and tests

### DIFF
--- a/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/src/vaadin-combo-box-dropdown-wrapper.js
@@ -280,7 +280,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   _setOverlayHeight() {
-    if (!this.opened || !this.positionTarget || !this._selector) {
+    if (!this.opened || !this.positionTarget) {
       return;
     }
 
@@ -398,10 +398,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
       return;
     }
     const visibleItemsCount = this._visibleItemsCount();
-    if (visibleItemsCount === undefined) {
-      // Scroller is not visible. Moving is unnecessary.
-      return;
-    }
 
     let targetIndex = index;
 
@@ -483,10 +479,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   _visibleItemsCount() {
-    if (!this._selector) {
-      return;
-    }
-
     // Ensure items are positioned
     this._selector.scrollToIndex(this._selector.firstVisibleIndex);
     // Ensure viewport boundaries are up-to-date

--- a/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/src/vaadin-combo-box-dropdown-wrapper.js
@@ -31,7 +31,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
         id="dropdown"
         hidden="[[_hidden(_items.*, loading)]]"
         position-target="[[positionTarget]]"
-        on-template-changed="_templateChanged"
         on-position-changed="_setOverlayHeight"
         disable-upgrade=""
         theme="[[theme]]"
@@ -183,12 +182,7 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   static get observers() {
-    return [
-      '_selectorChanged(_selector)',
-      '_loadingChanged(loading)',
-      '_openedChanged(opened, _items, loading)',
-      '_restoreScrollerPosition(_items)'
-    ];
+    return ['_loadingChanged(loading)', '_openedChanged(opened, _items, loading)', '_restoreScrollerPosition(_items)'];
   }
 
   _fireTouchAction(sourceEvent) {
@@ -259,7 +253,11 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   _initDropdown() {
     this.$.dropdown.removeAttribute('disable-upgrade');
 
-    this._templateChanged();
+    this._selector = this.$.dropdown.$.overlay.content.querySelector('#selector');
+    this._scroller = this.$.dropdown.$.overlay.content.querySelector('#scroller');
+
+    this._patchWheelOverScrolling();
+
     this._loadingChanged(this.loading);
 
     this.$.dropdown.$.overlay.addEventListener('touchend', (e) => this._fireTouchAction(e));
@@ -267,15 +265,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
 
     // Prevent blurring the input when clicking inside the overlay.
     this.$.dropdown.$.overlay.addEventListener('mousedown', (e) => e.preventDefault());
-  }
-
-  _templateChanged() {
-    if (this.$.dropdown.hasAttribute('disable-upgrade')) {
-      return;
-    }
-
-    this._selector = this.$.dropdown.$.overlay.content.querySelector('#selector');
-    this._scroller = this.$.dropdown.$.overlay.content.querySelector('#scroller');
   }
 
   _loadingChanged(loading) {
@@ -288,10 +277,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
     } else {
       this.$.dropdown.$.overlay.removeAttribute('loading');
     }
-  }
-
-  _selectorChanged() {
-    this._patchWheelOverScrolling();
   }
 
   _setOverlayHeight() {

--- a/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/src/vaadin-combo-box-dropdown-wrapper.js
@@ -342,10 +342,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
   }
 
   _onItemClick(e) {
-    if (e.detail && e.detail.sourceEvent && e.detail.sourceEvent.stopPropagation) {
-      this._stopPropagation(e.detail.sourceEvent);
-    }
-
     this.dispatchEvent(new CustomEvent('selection-changed', { detail: { item: e.model.item } }));
   }
 

--- a/src/vaadin-combo-box-dropdown-wrapper.js
+++ b/src/vaadin-combo-box-dropdown-wrapper.js
@@ -502,8 +502,6 @@ class ComboBoxDropdownWrapperElement extends PolymerElement {
       return;
     }
 
-    // Ensure items are rendered
-    this._selector.flushDebouncer('_debounceTemplate');
     // Ensure items are positioned
     this._selector.scrollToIndex(this._selector.firstVisibleIndex);
     // Ensure viewport boundaries are up-to-date

--- a/src/vaadin-combo-box-dropdown.js
+++ b/src/vaadin-combo-box-dropdown.js
@@ -82,7 +82,6 @@ class ComboBoxDropdownElement extends DisableUpgradeMixin(mixinBehaviors(IronRes
         id="overlay"
         hidden$="[[hidden]]"
         opened="[[opened]]"
-        template="{{template}}"
         style="align-items: stretch; margin: 0;"
         theme$="[[theme]]"
       >
@@ -100,11 +99,6 @@ class ComboBoxDropdownElement extends DisableUpgradeMixin(mixinBehaviors(IronRes
       opened: {
         type: Boolean,
         observer: '_openedChanged'
-      },
-
-      template: {
-        type: Object,
-        notify: true
       },
 
       /**

--- a/test/keyboard.test.js
+++ b/test/keyboard.test.js
@@ -249,30 +249,6 @@ describe('keyboard', () => {
       document.body.removeEventListener('keydown', listener);
     });
 
-    it('click event should not be propagated', () => {
-      const listener = document.body.addEventListener('click', () => {
-        throw new Error('Click event was propagated to body');
-      });
-
-      comboBox.$.overlay._selector
-        .querySelector('vaadin-combo-box-item')
-        .dispatchEvent(new CustomEvent('click', { composed: true, bubbles: true }));
-
-      document.body.removeEventListener('click', listener);
-    });
-
-    it('click event should not be propagated', () => {
-      const listener = document.body.addEventListener('click', () => {
-        throw new Error('Click event was propagated to body');
-      });
-
-      comboBox.$.overlay._selector
-        .querySelector('vaadin-combo-box-item')
-        .dispatchEvent(new CustomEvent('click', { composed: true, bubbles: true }));
-
-      document.body.removeEventListener('click', listener);
-    });
-
     it('should cancel typing with escape', () => {
       filter('baz');
 

--- a/test/selecting-items.test.js
+++ b/test/selecting-items.test.js
@@ -43,7 +43,8 @@ describe('selecting items', () => {
     document.addEventListener('click', clickSpy);
     comboBox.$.overlay._selector.dispatchEvent(
       new CustomEvent('click', {
-        bubbles: true
+        bubbles: true,
+        composed: true
       })
     );
     document.removeEventListener('click', clickSpy);


### PR DESCRIPTION
1. Starting from 51728a093932b278f7590e4bd5be0e690725d181, we use `click` event and it does not have `sourceEvent`, removed corresponding dead code.
2. The click event prevention was tested in two different places but one test was broken (it did not have `composed: true`). Updated that test to work properly and removed two other tests from the `keyboard` test suite as no longer needed.
3. Removed the `_debounceTemplate` call as that private method was only available in [Polymer 1.x](https://github.com/Polymer/polymer/blob/164a7cad43c1f4f75b406557f894ac3a4394972a/src/lib/template/templatizer.html#L186-L188) and no longer exists.
4. Removed code related to `template-changed` event which is also from Polymer 1.x era and is no longer needed.
5. Removed redundant checks for `this._selector` as the same methods also check for `this.opened`. With `_initDropdown` called when the `opened` is set to `true` we are sure the selector exists. So these checks are not necessary.