### PR TITLE
fix: do not fire custom-value-set event when readonly (CP: 14)

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -1050,7 +1050,7 @@ This program is available under Apache License Version 2.0, available at https:/
         event.composedPath()[0].focus();
         return;
       }
-      if (!this._closeOnBlurIsPrevented) {
+      if (!this.readonly && !this._closeOnBlurIsPrevented) {
         this._closeOrCommit();
       }
     }

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -313,6 +313,28 @@
         });
       });
     });
+
+    describe('custom-value-set event', () => {
+      let combobox;
+
+      beforeEach(() => {
+        combobox = fixture('combobox');
+        combobox.items = ['a', 'b'];
+        combobox.allowCustomValue = true;
+      });
+
+      it('should not fire custom-value-set event when combo-box is read-only', () => {
+        const spy = sinon.spy();
+        combobox.addEventListener('custom-value-set', spy);
+
+        combobox.readonly = true;
+        combobox.inputElement.value = 'not found';
+        combobox.focus();
+        fire('focusout', combobox.inputElement);
+
+        expect(spy.called).to.be.false;
+      });
+    });
   </script>
 
 </body>


### PR DESCRIPTION
cherry-pick of: https://github.com/vaadin/web-components/pull/2721
related to: https://github.com/vaadin/flow-components/issues/2135
