### PR TITLE
fix: add itemValuePath to selectItemChanged observer

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -264,7 +264,7 @@ This program is available under Apache License Version 2.0, available at https:/
         '_filteredItemsChanged(filteredItems.*, itemValuePath, itemLabelPath)',
         '_templateOrRendererChanged(_itemTemplate, renderer)',
         '_loadingChanged(loading)',
-        '_selectedItemChanged(selectedItem, itemLabelPath)',
+        '_selectedItemChanged(selectedItem, itemValuePath, itemLabelPath)',
         '_toggleElementChanged(_toggleElement)'
       ];
     }

--- a/test/using-object-values.html
+++ b/test/using-object-values.html
@@ -115,12 +115,17 @@
         expect(combobox.value).to.eql('bashcsdfsa');
       });
 
+      it('it should change combo-box value when value path changes', () => {
+        selectItem(0);
+        combobox.itemValuePath = 'custom';
+        expect(combobox.value).to.be.equal('bazs');
+      });
       it('should use toString if provided label and value paths are not found', () => {
-        combobox.itemValuePath = 'not.found';
-        combobox.itemLabelPath = 'not.found';
         combobox.items[0].toString = () => {
           return 'default';
         };
+        combobox.itemValuePath = 'not.found';
+        combobox.itemLabelPath = 'not.found';
 
         selectItem(0);
 


### PR DESCRIPTION
Back-porting https://github.com/vaadin/web-components/pull/2718
Fixes: https://github.com/vaadin/flow-components/issues/1880