### PR TITLE
fix: close vaadin-dialog on Esc in vaadin-combo-box

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -580,16 +580,32 @@ This program is available under Apache License Version 2.0, available at https:/
      */
     _onEscape(e) {
       if (this.autoOpenDisabled) {
-        this._focusedIndex = -1;
-        this.cancel();
-      } else if (this.opened) {
-        this._stopPropagation(e);
-
-        if (this._focusedIndex > -1) {
+        // Auto-open is disabled
+        if (this.value !== this._inputElementValue && this._inputElementValue.length > 0) {
+          // The input value has changed but the change hasn't been committed, so cancel it.
           this._focusedIndex = -1;
-          this._revertInputValue();
-        } else {
           this.cancel();
+        } else if (this.clearButtonVisible && !this.opened) {
+          // The clear button is visible and the overlay is closed, so clear the value.
+          this._clear();
+        }
+      } else {
+        // Auto-open is enabled
+        if (this.opened) {
+          // The overlay is open
+          e.stopPropagation();
+
+          if (this._focusedIndex > -1) {
+            // An item is focused, revert the input to the filtered value
+            this._focusedIndex = -1;
+            this._revertInputValue();
+          } else {
+            // No item is focused, cancel the change and close the overlay
+            this.cancel();
+          }
+        } else if (this.clearButtonVisible) {
+          // The clear button is visible and the overlay is closed, so clear the value.
+          this._clear();
         }
       }
     }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -607,7 +607,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.cancel();
           }
         } else if (this.clearButtonVisible && !!this.value) {
-          // this._stopPropagation(e);
+          this._stopPropagation(e);
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -585,7 +585,8 @@ This program is available under Apache License Version 2.0, available at https:/
           // The input value has changed but the change hasn't been committed, so cancel it.
           this._focusedIndex = -1;
           this.cancel();
-        } else if (this.clearButtonVisible && !this.opened) {
+        } else if (this.clearButtonVisible && !this.opened && !!this.value) {
+          this._stopPropagation(e);
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }
@@ -603,7 +604,8 @@ This program is available under Apache License Version 2.0, available at https:/
             // No item is focused, cancel the change and close the overlay
             this.cancel();
           }
-        } else if (this.clearButtonVisible) {
+        } else if (this.clearButtonVisible && !!this.value) {
+          this._stopPropagation(e);
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -595,7 +595,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // Auto-open is enabled
         if (this.opened) {
           // The overlay is open
-          e.stopPropagation();
+          this._stopPropagation(e);
 
           if (this._focusedIndex > -1) {
             // An item is focused, revert the input to the filtered value

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -583,6 +583,7 @@ This program is available under Apache License Version 2.0, available at https:/
         // Auto-open is disabled
         if (this.value !== this._inputElementValue && this._inputElementValue.length > 0) {
           // The input value has changed but the change hasn't been committed, so cancel it.
+          this._stopPropagation(e);
           this._focusedIndex = -1;
           this.cancel();
         } else if (this.clearButtonVisible && !this.opened && !!this.value) {

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -607,7 +607,7 @@ This program is available under Apache License Version 2.0, available at https:/
             this.cancel();
           }
         } else if (this.clearButtonVisible && !!this.value) {
-          this._stopPropagation(e);
+          // this._stopPropagation(e);
           // The clear button is visible and the overlay is closed, so clear the value.
           this._clear();
         }

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -581,8 +581,9 @@ This program is available under Apache License Version 2.0, available at https:/
     _onEscape(e) {
       if (this.autoOpenDisabled) {
         // Auto-open is disabled
-        if (this.value !== this._inputElementValue && this._inputElementValue.length > 0) {
-          // The input value has changed but the change hasn't been committed, so cancel it.
+        if (this.opened || (this.value !== this._inputElementValue && this._inputElementValue.length > 0)) {
+          // The overlay is open or
+          // the input value has changed but the change hasn't been committed, so cancel it.
           this._stopPropagation(e);
           this._focusedIndex = -1;
           this.cancel();

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -391,21 +391,6 @@ This program is available under Apache License Version 2.0, available at https:/
           this._toggleElement = this.$.toggleButton;
           this._clearElement = this.inputElement.shadowRoot.querySelector('[part="clear-button"]');
 
-          // Stop propagation of Esc in capturing phase so that
-          // vaadin-text-field will not handle Esc as a shortcut
-          // to clear the value.
-          // We need to set this listener for "this.inputElement"
-          // instead of just "this", otherwise keyboard navigation behaviour
-          // breaks a bit on Safari and some related tests fail.
-          this.inputElement.addEventListener('keydown', e => {
-            if (this._isEventKey(e, 'esc')) {
-              this._stopPropagation(e);
-              // Trigger _onEscape method of vaadin-combo-box-mixin because
-              // bubbling phase is not reached.
-              this._onEscape(e);
-            }
-          }, true);
-
           this._nativeInput.setAttribute('role', 'combobox');
           this._nativeInput.setAttribute('aria-autocomplete', 'list');
           this._updateAriaExpanded();

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -394,9 +394,6 @@ This program is available under Apache License Version 2.0, available at https:/
           // Stop propagation of Esc in capturing phase so that
           // vaadin-text-field will not handle Esc as a shortcut
           // to clear the value.
-          // We need to set this listener for "this.inputElement"
-          // instead of just "this", otherwise keyboard navigation behaviour
-          // breaks a bit on Safari and some related tests fail.
           this.addEventListener('keydown', e => {
             if (this._isEventKey(e, 'esc')) {
               // Trigger _onEscape method of vaadin-combo-box-mixin because

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -6,7 +6,6 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../vaadin-text-field/src/vaadin-text-field.html">
-<!-- <link rel="import" href="vaadin-combo-box-text-field.html"> -->
 <link rel="import" href="../../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="vaadin-combo-box-mixin.html">
@@ -388,13 +387,23 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
 
-          // override keyDown listener on internal vaadin-text-field
-          // to avoid having it act on Esc key press
-          this.inputElement._onKeyDown = (e) => {/* do nothing */};
-
           this._nativeInput = this.inputElement.focusElement;
           this._toggleElement = this.$.toggleButton;
           this._clearElement = this.inputElement.shadowRoot.querySelector('[part="clear-button"]');
+
+          // Stop propagation of Esc in capturing phase so that
+          // vaadin-text-field will not handle Esc as a shortcut
+          // to clear the value.
+          // We need to set this listener for "this.inputElement"
+          // instead of just "this", otherwise keyboard navigation behaviour
+          // breaks a bit on Safari and some related tests fail.
+          this.inputElement.addEventListener('keydown', e => {
+            if (this._isEventKey(e, 'esc')) {
+              // Trigger _onEscape method of vaadin-combo-box-mixin because
+              // bubbling phase is not reached.
+              this._onEscape(e);
+            }
+          }, true);
 
           this._nativeInput.setAttribute('role', 'combobox');
           this._nativeInput.setAttribute('aria-autocomplete', 'list');

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -6,6 +6,7 @@ This program is available under Apache License Version 2.0, available at https:/
 
 <link rel="import" href="../../polymer/polymer-element.html">
 <link rel="import" href="../../vaadin-text-field/src/vaadin-text-field.html">
+<!-- <link rel="import" href="vaadin-combo-box-text-field.html"> -->
 <link rel="import" href="../../vaadin-control-state-mixin/vaadin-control-state-mixin.html">
 <link rel="import" href="../../vaadin-themable-mixin/vaadin-themable-mixin.html">
 <link rel="import" href="vaadin-combo-box-mixin.html">
@@ -386,6 +387,10 @@ This program is available under Apache License Version 2.0, available at https:/
         /** @protected */
         ready() {
           super.ready();
+
+          // override keyDown listener on internal vaadin-text-field
+          // to avoid having it act on Esc key press
+          this.inputElement._onKeyDown = (e) => {/* do nothing */};
 
           this._nativeInput = this.inputElement.focusElement;
           this._toggleElement = this.$.toggleButton;

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -397,7 +397,7 @@ This program is available under Apache License Version 2.0, available at https:/
           // We need to set this listener for "this.inputElement"
           // instead of just "this", otherwise keyboard navigation behaviour
           // breaks a bit on Safari and some related tests fail.
-          this.inputElement.addEventListener('keydown', e => {
+          this.addEventListener('keydown', e => {
             if (this._isEventKey(e, 'esc')) {
               // Trigger _onEscape method of vaadin-combo-box-mixin because
               // bubbling phase is not reached.

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -684,6 +684,7 @@
         comboBox.opened = true;
         esc();
         expect(comboBox.value).to.equal('bar');
+        expect(comboBox._inputElementValue).to.equal('bar');
       });
 
     });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -284,11 +284,12 @@
       });
 
       it('escape key event should not be propagated', () => {
-        const listener = document.body.addEventListener('keydown', e => {
+        const listener = e => {
           if (e.keyCode == 27) {
             throw new Error('Escape key was propagated to body');
           }
-        });
+        };
+        document.body.addEventListener('keydown', listener);
 
         esc();
 
@@ -571,6 +572,8 @@
     describe('auto open disabled', () => {
 
       beforeEach(() => {
+        comboBox = fixture('combobox');
+        comboBox.items = ['foo', 'bar', 'baz'];
         comboBox.autoOpenDisabled = true;
       });
 

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -662,7 +662,8 @@
         expect(comboBox.value).to.equal('');
       });
 
-      it('should revert changed input value on esc if clear button is visible', () => {
+      // TODO: unskip when https://github.com/vaadin/vaadin-text-field/pull/585 gets released
+      it.skip('should revert changed input value on esc if clear button is visible', () => {
         comboBox.value = 'bar';
         comboBox.clearButtonVisible = true;
         inputText('foo');
@@ -671,8 +672,7 @@
         expect(comboBox.value).to.equal('bar');
       });
 
-      // TODO: unskip when https://github.com/vaadin/vaadin-text-field/pull/585 gets released
-      it.skip('should clear the value on esc if clear button is visible', () => {
+      it('should clear the value on esc if clear button is visible', () => {
         comboBox.value = 'bar';
         comboBox.clearButtonVisible = true;
         esc();

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -435,6 +435,25 @@
           done();
         }, 1);
       });
+
+      it('should not clear the value on esc if clear button is not visible', () => {
+        esc();
+        expect(comboBox.value).to.equal('bar');
+      });
+
+      it('should clear the value on esc if clear button is visible', () => {
+        comboBox.close();
+        comboBox.clearButtonVisible = true;
+        esc(); // it is clearing the combo-box input but not the combo-box value
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should not clear the value on esc if the overlay is open', () => {
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        esc();
+        expect(comboBox.value).to.equal('bar');
+      });
     });
 
     // TODO: these tests are here to prevent possible regressions with using
@@ -627,6 +646,30 @@
         esc();
         expect(comboBox._inputElementValue).to.equal('');
         expect(comboBox.value).to.equal('');
+      });
+
+      it('should revert changed input value on esc if clear button is visible', () => {
+        comboBox.value = 'bar';
+        comboBox.clearButtonVisible = true;
+        inputText('foo');
+        esc();
+        expect(comboBox._inputElementValue).to.equal('bar');
+        expect(comboBox.value).to.equal('bar');
+      });
+
+      it('should clear the value on esc if clear button is visible', () => {
+        comboBox.value = 'bar';
+        comboBox.clearButtonVisible = true;
+        esc();
+        expect(comboBox.value).to.equal('');
+      });
+
+      it('should not clear the value on esc if the overlay is open', () => {
+        comboBox.value = 'bar';
+        comboBox.clearButtonVisible = true;
+        comboBox.opened = true;
+        esc();
+        expect(comboBox.value).to.equal('bar');
       });
 
     });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -296,6 +296,20 @@
         document.body.removeEventListener('keydown', listener);
       });
 
+      it('escape key event should be propagated if dropdown is closed', () => {
+        let propagated = false;
+        const listener = e => {
+          if (e.keyCode === 27) {
+            propagated = true;
+          }
+        };
+        comboBox.close();
+        document.body.addEventListener('keydown', listener);
+        esc();
+        expect(propagated).to.be.true;
+        document.body.removeEventListener('keydown', listener);
+      });
+
       it('click event should not be propagated', () => {
         const listener = document.body.addEventListener('click', () => {
           throw new Error('Click event was propagated to body');

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -89,6 +89,21 @@
       comboBox.items = ['foo', 'bar', 'baz'];
     });
 
+    it('should not propagate esc keydown event when overlay is closed, clear button is visible and value is not empty', () => {
+      comboBox.value = 'bar';
+      comboBox.clearButtonVisible = true;
+      const keyDownSpy = sinon.spy();
+      const listener = e => {
+        if (e.keyCode == 27) {
+          keyDownSpy();
+        }
+      };
+      document.body.addEventListener('keydown', listener);
+      esc();
+      expect(keyDownSpy).to.not.be.called;
+      document.body.removeEventListener('keydown', listener);
+    });
+
     describe('opening the overlay', () => {
       it('should open the overlay with arrow down and not focus any item', () => {
         arrowDown();
@@ -283,7 +298,7 @@
         expect(comboBox.opened).to.equal(false);
       });
 
-      it('escape key event should not be propagated', () => {
+      it('escape key event should not be propagated when overlay is open', () => {
         const listener = e => {
           if (e.keyCode == 27) {
             throw new Error('Escape key was propagated to body');
@@ -685,6 +700,38 @@
         esc();
         expect(comboBox.value).to.equal('bar');
         expect(comboBox._inputElementValue).to.equal('bar');
+      });
+
+      describe('esc keydown event propagation', () => {
+        it('should not propagate when input value is not empty', () => {
+          inputText('foo');
+          const keyDownSpy = sinon.spy();
+          const listener = e => {
+            if (e.keyCode == 27) {
+              keyDownSpy();
+            }
+          };
+          document.body.addEventListener('keydown', listener);
+          esc();
+          expect(keyDownSpy).to.not.be.called;
+          document.body.removeEventListener('keydown', listener);
+        });
+
+        it('should not propagate when clear button is visible and the value is not empty', () => {
+          comboBox.value = 'bar';
+          comboBox.clearButtonVisible = true;
+
+          const keyDownSpy = sinon.spy();
+          const listener = e => {
+            if (e.keyCode == 27) {
+              keyDownSpy();
+            }
+          };
+          document.body.addEventListener('keydown', listener);
+          esc();
+          expect(keyDownSpy).to.not.be.called;
+          document.body.removeEventListener('keydown', listener);
+        });
       });
 
     });

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -662,8 +662,7 @@
         expect(comboBox.value).to.equal('');
       });
 
-      // TODO: unskip when https://github.com/vaadin/vaadin-text-field/pull/585 gets released
-      it.skip('should revert changed input value on esc if clear button is visible', () => {
+      it('should revert changed input value on esc if clear button is visible', () => {
         comboBox.value = 'bar';
         comboBox.clearButtonVisible = true;
         inputText('foo');

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -31,6 +31,7 @@
 <script>
 
   describe('keyboard navigation', () => {
+    const KEY_ESC = 27;
 
     // Not need to test in iOS, just speed up build.
     if (ios || android) {
@@ -92,16 +93,12 @@
     it('should not propagate esc keydown event when overlay is closed, clear button is visible and value is not empty', () => {
       comboBox.value = 'bar';
       comboBox.clearButtonVisible = true;
+
       const keyDownSpy = sinon.spy();
-      const listener = e => {
-        if (e.keyCode == 27) {
-          keyDownSpy();
-        }
-      };
-      document.body.addEventListener('keydown', listener);
+      document.body.addEventListener('keydown', keyDownSpy);
       esc();
-      expect(keyDownSpy).to.not.be.called;
-      document.body.removeEventListener('keydown', listener);
+      document.body.removeEventListener('keydown', keyDownSpy);
+      expect(keyDownSpy).not.to.have.been.calledWithMatch({keyCode: KEY_ESC});
     });
 
     describe('opening the overlay', () => {
@@ -300,7 +297,7 @@
 
       it('escape key event should not be propagated when overlay is open', () => {
         const listener = e => {
-          if (e.keyCode == 27) {
+          if (e.keyCode === KEY_ESC) {
             throw new Error('Escape key was propagated to body');
           }
         };
@@ -705,16 +702,12 @@
       describe('esc keydown event propagation', () => {
         it('should not propagate when input value is not empty', () => {
           inputText('foo');
+
           const keyDownSpy = sinon.spy();
-          const listener = e => {
-            if (e.keyCode == 27) {
-              keyDownSpy();
-            }
-          };
-          document.body.addEventListener('keydown', listener);
+          document.body.addEventListener('keydown', keyDownSpy);
           esc();
-          expect(keyDownSpy).to.not.be.called;
-          document.body.removeEventListener('keydown', listener);
+          document.body.removeEventListener('keydown', keyDownSpy);
+          expect(keyDownSpy).not.to.have.been.calledWithMatch({keyCode: KEY_ESC});
         });
 
         it('should not propagate when clear button is visible and the value is not empty', () => {
@@ -722,15 +715,10 @@
           comboBox.clearButtonVisible = true;
 
           const keyDownSpy = sinon.spy();
-          const listener = e => {
-            if (e.keyCode == 27) {
-              keyDownSpy();
-            }
-          };
-          document.body.addEventListener('keydown', listener);
+          document.body.addEventListener('keydown', keyDownSpy);
           esc();
-          expect(keyDownSpy).to.not.be.called;
-          document.body.removeEventListener('keydown', listener);
+          document.body.removeEventListener('keydown', keyDownSpy);
+          expect(keyDownSpy).not.to.have.been.calledWithMatch({keyCode: KEY_ESC});
         });
       });
 

--- a/test/keyboard.html
+++ b/test/keyboard.html
@@ -657,7 +657,8 @@
         expect(comboBox.value).to.equal('bar');
       });
 
-      it('should clear the value on esc if clear button is visible', () => {
+      // TODO: unskip when https://github.com/vaadin/vaadin-text-field/pull/585 gets released
+      it.skip('should clear the value on esc if clear button is visible', () => {
         comboBox.value = 'bar';
         comboBox.clearButtonVisible = true;
         esc();


### PR DESCRIPTION
## Description

Pressing the <kbd>Esc</kbd> key on a closed `vaadin-combo-box` placed in a `vaadin-dialog` now closes the dialog.

Fixes https://github.com/vaadin/web-components/issues/984

## Type of change

- [x] Bugfix
