### PR TITLE
fix: prevent combo box from closing other overlays (CP: 14)

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -1,0 +1,5 @@
+{
+  "lint": {
+    "ignoreWarnings": ["overriding-private"]
+  }
+}

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -23,7 +23,8 @@ This program is available under Apache License Version 2.0, available at https:/
     <vaadin-combo-box-overlay
         id="overlay"
         hidden$="[[hidden]]"
-        opened="[[opened]]"
+        position-target="[[positionTarget]]"
+        opened="{{opened}}"
         template="{{template}}"
         style="align-items: stretch; margin: 0;"
         theme$="[[theme]]">
@@ -65,6 +66,17 @@ This program is available under Apache License Version 2.0, available at https:/
         return 'vaadin-combo-box-overlay';
       }
 
+      static get properties() {
+        return {
+          /**
+           * The element to position/align the dropdown by.
+           */
+          positionTarget: {
+            type: Object
+          }
+        };
+      }
+
       static get template() {
         if (!memoizedTemplate) {
           memoizedTemplate = super.template.cloneNode(true);
@@ -92,6 +104,19 @@ This program is available under Apache License Version 2.0, available at https:/
         loader.setAttribute('part', 'loader');
         const content = this.shadowRoot.querySelector('[part~="content"]');
         content.parentNode.insertBefore(loader, content);
+      }
+
+      /**
+       * Override OverlayElement._outsideClickListener to prevent closing the
+       * overlay when clicking into the combo box input element
+       * @param event
+       * @private
+       */
+      _outsideClickListener(event) {
+        const eventPath = event.composedPath();
+        if (!eventPath.includes(this.positionTarget) && !eventPath.includes(this)) {
+          this.close();
+        }
       }
     }
 
@@ -147,7 +172,6 @@ This program is available under Apache License Version 2.0, available at https:/
       constructor() {
         super();
         this._boundSetPosition = this._setPosition.bind(this);
-        this._boundOutsideClickListener = this._outsideClickListener.bind(this);
       }
 
       connectedCallback() {
@@ -203,23 +227,10 @@ This program is available under Apache License Version 2.0, available at https:/
           this._setPosition();
 
           window.addEventListener('scroll', this._boundSetPosition, true);
-          document.addEventListener('click', this._boundOutsideClickListener, true);
           this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-opened', {bubbles: true, composed: true}));
         } else if (!this.__emptyItems) {
           window.removeEventListener('scroll', this._boundSetPosition, true);
-          document.removeEventListener('click', this._boundOutsideClickListener, true);
           this.dispatchEvent(new CustomEvent('vaadin-combo-box-dropdown-closed', {bubbles: true, composed: true}));
-        }
-      }
-
-
-      // We need to listen on 'click' event and capture it and close the overlay before
-      // propagating the event to the listener in the button. Otherwise, if the clicked button would call
-      // open(), this would happen: https://www.youtube.com/watch?v=Z86V_ICUCD4
-      _outsideClickListener(event) {
-        const eventPath = event.composedPath();
-        if (eventPath.indexOf(this.positionTarget) < 0 && eventPath.indexOf(this.$.overlay) < 0) {
-          this.opened = false;
         }
       }
 

--- a/src/vaadin-combo-box-dropdown.html
+++ b/src/vaadin-combo-box-dropdown.html
@@ -114,7 +114,7 @@ This program is available under Apache License Version 2.0, available at https:/
        */
       _outsideClickListener(event) {
         const eventPath = event.composedPath();
-        if (!eventPath.includes(this.positionTarget) && !eventPath.includes(this)) {
+        if (eventPath.indexOf(this.positionTarget) < 0 && eventPath.indexOf(this) < 0) {
           this.close();
         }
       }

--- a/test/vaadin-combo-box-dropdown.html
+++ b/test/vaadin-combo-box-dropdown.html
@@ -30,12 +30,23 @@
     </template>
   </test-fixture>
 
+  <test-fixture id="in-modal-dialog">
+    <template>
+      <vaadin-dialog>
+        <template>
+          <vaadin-combo-box items="[1,2,3]"></vaadin-combo-box>
+        </template>
+      </vaadin-dialog>
+    </template>
+  </test-fixture>
+
   <script>
     describe('vaadin-combo-box-dropdown', () => {
       let dropdown, overlay;
 
       beforeEach(() => {
         dropdown = fixture('default');
+        dropdown.positionTarget = document.createElement('button');
         overlay = dropdown.$.overlay;
       });
 
@@ -77,7 +88,7 @@
 
       function touchstart(node) {
         const event = new CustomEvent('touchstart', {bubbles: true, cancelable: true});
-    
+
         const nodeRect = node.getBoundingClientRect();
         const clientX = nodeRect.left;
         const clientY = nodeRect.top;
@@ -108,6 +119,44 @@
         touchstart(cbBox);
         requestAnimationFrame(() => {
           expect(cbBoxDropdownWrapper.$.dropdown.$.overlay._last).to.be.true;
+          done();
+        });
+      });
+    });
+
+    describe('in modal dialog', () => {
+      let backdrop;
+      let dialog;
+      let comboBox;
+
+      beforeEach((done) => {
+        dialog = fixture('in-modal-dialog');
+        dialog.opened = true;
+        requestAnimationFrame(() => {
+          comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
+          backdrop = dialog.$.overlay.$.backdrop;
+          done();
+        });
+      });
+
+      it('should not close the dialog on outside click', (done) => {
+        comboBox.open();
+
+        requestAnimationFrame(() => {
+          // For this test we need to remove the focus from the input element without closing the combobox dropdown,
+          // otherwise the issue is not reproducible, because the combo box overlay will be closed by the focus out
+          // event, rather than the click event. While this shouldn't never be the case for the combo box itself,
+          // this is a valid case for other components using combo box, such as time picker.
+          comboBox.addEventListener("focusout", e => {
+            e.stopPropagation()
+          }, true);
+          comboBox.blur();
+          expect(comboBox.opened).to.be.true;
+
+          // Clicking on backdrop should close the combo box overlay, but not the dialog overlay
+          backdrop.click();
+          expect(comboBox.opened).to.be.false;
+          expect(dialog.opened).to.be.true;
           done();
         });
       });

--- a/test/vaadin-combo-box-dropdown.html
+++ b/test/vaadin-combo-box-dropdown.html
@@ -129,6 +129,15 @@
       let dialog;
       let comboBox;
 
+      function outsideClick() {
+        // Move focus to body
+        document.body.tabIndex = 0;
+        document.body.focus();
+        document.body.tabIndex = -1;
+        // Outside click
+        document.body.click();
+      }
+
       beforeEach((done) => {
         dialog = fixture('in-modal-dialog');
         dialog.opened = true;
@@ -153,8 +162,8 @@
           comboBox.blur();
           expect(comboBox.opened).to.be.true;
 
-          // Clicking on backdrop should close the combo box overlay, but not the dialog overlay
-          backdrop.click();
+          // Clicking outside should close the combo box overlay, but not the dialog overlay
+          outsideClick();
           expect(comboBox.opened).to.be.false;
           expect(dialog.opened).to.be.true;
           done();

--- a/test/vaadin-combo-box-dropdown.html
+++ b/test/vaadin-combo-box-dropdown.html
@@ -125,7 +125,6 @@
     });
 
     describe('in modal dialog', () => {
-      let backdrop;
       let dialog;
       let comboBox;
 
@@ -143,7 +142,6 @@
         dialog.opened = true;
         requestAnimationFrame(() => {
           comboBox = dialog.$.overlay.querySelector('vaadin-combo-box');
-          backdrop = dialog.$.overlay.$.backdrop;
           done();
         });
       });

--- a/test/vaadin-combo-box-dropdown.html
+++ b/test/vaadin-combo-box-dropdown.html
@@ -147,8 +147,8 @@
           // otherwise the issue is not reproducible, because the combo box overlay will be closed by the focus out
           // event, rather than the click event. While this shouldn't never be the case for the combo box itself,
           // this is a valid case for other components using combo box, such as time picker.
-          comboBox.addEventListener("focusout", e => {
-            e.stopPropagation()
+          comboBox.addEventListener('focusout', e => {
+            e.stopPropagation();
           }, true);
           comboBox.blur();
           expect(comboBox.opened).to.be.true;


### PR DESCRIPTION
Cherry-pick of: https://github.com/vaadin/web-components/pull/3110
Fixes: https://github.com/vaadin/web-components/issues/2978