### PR TITLE
Backported webcomponents#4081

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -1099,7 +1099,10 @@ This program is available under Apache License Version 2.0, available at https:/
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
      */
     validate() {
-      return !(this.invalid = !this.checkValidity());
+      const isValid = this.checkValidity();
+      this.invalid = !isValid;
+      this.dispatchEvent(new CustomEvent('validated', {detail: {valid: isValid}}));
+      return isValid;
     }
 
     /**
@@ -1209,6 +1212,14 @@ This program is available under Apache License Version 2.0, available at https:/
      * Fired when value changes.
      * To comply with https://developer.mozilla.org/en-US/docs/Web/Events/change
      * @event change
+     */
+
+    /**
+     * Fired whenever the field is validated.
+     *
+     * @event validated
+     * @param {Object} detail
+     * @param {boolean} detail.valid the result of the validation.
      */
   };
 </script>

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -75,6 +75,28 @@
         expect(comboBox.validate()).to.equal(true);
         expect(comboBox.invalid).to.be.equal(false);
       });
+
+      it('should fire a validated event on validation success', () => {
+        const validatedSpy = sinon.spy();
+        comboBox.addEventListener('validated', validatedSpy);
+        comboBox.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.true;
+      });
+
+      it('should fire a validated event on validation failure', () => {
+        const validatedSpy = sinon.spy();
+        comboBox.addEventListener('validated', validatedSpy);
+        comboBox.required = true;
+        comboBox.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.false;
+      });
+
     });
 
     describe('using the field in iron-form', () => {


### PR DESCRIPTION
## Description

Backporting webcomponents#4081 as part of an EoD task

## Type of change

- [ ] Bugfix
- [x] Feature

## Checklist

- [x] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [x] I have added a description following the guideline.
- [x] The issue is created in the corresponding repository and I have referenced it.
- [x] I have added tests to ensure my change is effective and works as intended.
- [x] New and existing tests are passing locally with my change.
- [x] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [x] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
