### PR TITLE
fix: prevent initial validation when the field is initialized as invalid

### DIFF
--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "no-unused-vars": 0
   },
@@ -34,6 +37,7 @@
     "_fixture": false,
     "gemini": false,
     "flush": false,
-    "ShadyDOM": false
+    "ShadyDOM": false,
+    "nextRender": false
   }
 }

--- a/test/common.js
+++ b/test/common.js
@@ -81,6 +81,12 @@ var getItemArray = length => {
     .map((item, index) => 'item ' + index);
 };
 
+var nextRender = (element) => {
+  return new Promise(resolve => {
+    Polymer.RenderStatus.afterNextRender(element, resolve);
+  });
+};
+
 // IE11 throws errors when the fixture is removed from the DOM and the focus remains in the native input.
 // Also, FF and Chrome are unable to focus the input when tests are run in the headless window manager used in Travis
 function monkeyPatchTextFieldFocus() {

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -77,6 +77,42 @@
       });
     });
 
+    describe('initial validation', () => {
+      let comboBox;
+      let validateSpy;
+
+      beforeEach(() => {
+        comboBox = document.createElement('vaadin-combo-box');
+        comboBox.allowCustomValue = true;
+        validateSpy = sinon.spy(comboBox, 'validate');
+      });
+
+      afterEach(() => {
+        comboBox.remove();
+      });
+
+      it('should not validate by default', async() => {
+        document.body.appendChild(comboBox);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value', async() => {
+        comboBox.value = 'foo';
+        document.body.appendChild(comboBox);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+
+      it('should not validate when the field has an initial value and invalid', async() => {
+        comboBox.value = 'foo';
+        comboBox.invalid = true;
+        document.body.appendChild(comboBox);
+        await nextRender();
+        expect(validateSpy.called).to.be.false;
+      });
+    });
+
     describe('using the field in iron-form', () => {
       let comboBox, ironForm, form;
 


### PR DESCRIPTION
Backports web-components#4172 as part of an EoD task

> ## Description
> This PR adds unit tests verifying that no initial validation happens for `combo-box`.
> 
> Part of #4150
> 
> ## Type of change
> * [x]  Internal
> 
> ## Checklist
> * [x]  I have read the contribution guide: https://vaadin.com/docs-beta/latest/guide/contributing/overview/
> * [x]  I have added a description following the guideline.
> * [x]  The issue is created in the corresponding repository and I have referenced it.
> * [x]  I have added tests to ensure my change is effective and works as intended.
> * [x]  New and existing tests are passing locally with my change.
> * [x]  I have performed self-review and corrected misspellings.
> 
> #### Additional for `Feature` type of change
> * [ ]  Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.

