### PR TITLE
feat: fire a validated event on validation and add shouldSetInvalid method

### DIFF
--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -1099,7 +1099,10 @@ This program is available under Apache License Version 2.0, available at https:/
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
      */
     validate() {
-      return !(this.invalid = !this.checkValidity());
+      const isValid = this.checkValidity();
+      this.invalid = !isValid;
+      this.dispatchEvent(new CustomEvent('validated', {detail: {valid: isValid}}));
+      return isValid;
     }
 
     /**
@@ -1209,6 +1212,14 @@ This program is available under Apache License Version 2.0, available at https:/
      * Fired when value changes.
      * To comply with https://developer.mozilla.org/en-US/docs/Web/Events/change
      * @event change
+     */
+
+    /**
+     * Fired whenever the field is validated.
+     *
+     * @event validated
+     * @param {Object} detail
+     * @param {boolean} detail.valid the result of the validation.
      */
   };
 </script>

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -1094,13 +1094,34 @@ This program is available under Apache License Version 2.0, available at https:/
     }
 
     /**
+     * @param {boolean} invalid
+     * @protected
+     */
+    _setInvalid(invalid) {
+      if (this._shouldSetInvalid(invalid)) {
+        this.invalid = invalid;
+      }
+    }
+
+    /**
+     * Override this method to define whether the given `invalid` state should be set.
+     *
+     * @param {boolean} _invalid
+     * @return {boolean}
+     * @protected
+     */
+    _shouldSetInvalid(_invalid) {
+      return true;
+    }
+  
+    /**
      * Returns true if `value` is valid, and sets the `invalid` flag appropriately.
      *
      * @return {boolean} True if the value is valid and sets the `invalid` flag appropriately
      */
     validate() {
       const isValid = this.checkValidity();
-      this.invalid = !isValid;
+      this._setInvalid(!isValid);
       this.dispatchEvent(new CustomEvent('validated', {detail: {valid: isValid}}));
       return isValid;
     }

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,4 +1,7 @@
 {
+  "parserOptions": {
+    "ecmaVersion": 8
+  },
   "rules": {
     "no-unused-vars": 0
   },

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -3,6 +3,7 @@
     "ecmaVersion": 8
   },
   "rules": {
+    "no-undef": 0,
     "no-unused-vars": 0
   },
   "globals": {

--- a/test/form-input.html
+++ b/test/form-input.html
@@ -75,6 +75,28 @@
         expect(comboBox.validate()).to.equal(true);
         expect(comboBox.invalid).to.be.equal(false);
       });
+
+      it('should fire a validated event on validation success', () => {
+        const validatedSpy = sinon.spy();
+        comboBox.addEventListener('validated', validatedSpy);
+        comboBox.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.true;
+      });
+
+      it('should fire a validated event on validation failure', () => {
+        const validatedSpy = sinon.spy();
+        comboBox.addEventListener('validated', validatedSpy);
+        comboBox.required = true;
+        comboBox.validate();
+
+        expect(validatedSpy.calledOnce).to.be.true;
+        const event = validatedSpy.firstCall.args[0];
+        expect(event.detail.valid).to.be.false;
+      });
+
     });
 
     describe('using the field in iron-form', () => {

--- a/test/invalid-common.js
+++ b/test/invalid-common.js
@@ -1,0 +1,48 @@
+const cachedWrappers = [];
+const templates = {};
+/**
+ * Creates a wrapper as a direct child of `<body>` to put the tested element into.
+ * Need to be in the DOM to test for example `connectedCallback()` on elements.
+ *
+ * @param {!Element} parentNode
+ * @return {Element} wrapping node
+ */
+function fixtureWrapper(parentNode = document.createElement('div')) {
+  document.body.appendChild(parentNode);
+  cachedWrappers.push(parentNode);
+  return parentNode;
+}
+
+// # sourceMappingURL=fixture-wrapper.js.map
+
+/**
+ * Creates a `<template>` element from a provided string template.
+ *
+ * @param {string} html
+ * @return {HTMLTemplateElement}
+ */
+function template(html) {
+  let tpl = templates[html];
+  if (!tpl) {
+    tpl = document.createElement('template');
+    tpl.innerHTML = html;
+    templates[html] = tpl;
+  }
+  return tpl;
+}
+/**
+ * Setups an element synchronously from the provided string template and puts it in the DOM.
+ * Uses `document.importNode` to ensure proper custom elements upgrade timings.
+ *
+ * @template {Element} T - Is an element or a node
+ * @param {!string} html
+ * @param {Element=} wrapper
+ * @return {T}
+ */
+function fixtureSync(html, wrapper) {
+  const tpl = template(html);
+  const parentNode = fixtureWrapper(wrapper);
+  parentNode.appendChild(document.importNode(tpl.content, true));
+  return parentNode.firstElementChild;
+}
+// # sourceMappingURL=fixture-no-side-effect.js.map

--- a/test/invalid-common.js
+++ b/test/invalid-common.js
@@ -13,7 +13,6 @@ function fixtureWrapper(parentNode = document.createElement('div')) {
   return parentNode;
 }
 
-// # sourceMappingURL=fixture-wrapper.js.map
 
 /**
  * Creates a `<template>` element from a provided string template.
@@ -45,4 +44,3 @@ function fixtureSync(html, wrapper) {
   parentNode.appendChild(document.importNode(tpl.content, true));
   return parentNode.firstElementChild;
 }
-// # sourceMappingURL=fixture-no-side-effect.js.map

--- a/test/vaadin-combo-box.html
+++ b/test/vaadin-combo-box.html
@@ -10,6 +10,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <link rel="import" href="common-imports.html">
   <script src="common.js"></script>
+  <script src="invalid-common.js"></script>
 </head>
 
 <body>
@@ -525,6 +526,31 @@
           comboBox.readonly = true;
           expect(getComputedStyle(clearButton).display).to.equal('none');
         });
+      });
+    });
+
+    describe('combo-box invalid', () => {
+      let element;
+    
+      function nextRender(element) {
+        return new Promise(resolve => {
+          Polymer.RenderStatus.afterNextRender(element, resolve);
+        });
+      }
+    
+      beforeEach(async() => {
+        element = fixtureSync('<vaadin-combo-box></vaadin-combo-box>');
+        element._shouldSetInvalid = (invalid) => invalid;
+        await nextRender();
+      });
+
+      it('should set invalid only when it is true', async() => {
+        element.required = true;
+        element.validate();
+        expect(element.invalid).to.be.true;
+        element.value = 'value';
+        element.validate();
+        expect(element.invalid).to.be.true;
       });
     });
   </script>


### PR DESCRIPTION
<!-- PLEASE READ AND FOLLOW THE TEMPLATE! THE PR CAN BE REJECTED OTHERWISE (This line should be removed when submitting) -->

## Description

1.Fires a validated event when the web component's validation takes place.
2.Adds a protected shouldSetInvalid() method. It will be used for preventing the web component from modifying the client-side invalid state on the Flow side afterward."

Fixes # (issue)

## Type of change

- [ ] Feature

## Checklist

- [ ] I have read the contribution guide: https://vaadin.com/docs/latest/guide/contributing/overview/
- [ ] I have added a description following the guideline.
- [ ] The issue is created in the corresponding repository and I have referenced it.
- [ ] I have added tests to ensure my change is effective and works as intended.
- [ ] New and existing tests are passing locally with my change.
- [ ] I have performed self-review and corrected misspellings.

#### Additional for `Feature` type of change

- [ ] Enhancement / new feature was discussed in a corresponding GitHub issue and Acceptance Criteria were created.
