### PR TITLE
chore: bump vaadin-text-field dependency to 2.9.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -36,7 +36,7 @@
     "polymer": "^2.0.0",
     "vaadin-control-state-mixin": "vaadin/vaadin-control-state-mixin#^2.2.2",
     "vaadin-overlay": "vaadin/vaadin-overlay#^3.5.0",
-    "vaadin-text-field": "vaadin/vaadin-text-field#^2.8.0",
+    "vaadin-text-field": "^2.9.0",
     "vaadin-themable-mixin": "vaadin/vaadin-themable-mixin#^1.6.1",
     "vaadin-lumo-styles": "vaadin/vaadin-lumo-styles#^1.1.1",
     "vaadin-material-styles": "vaadin/vaadin-material-styles#^1.1.2",

--- a/package-lock-p3.json
+++ b/package-lock-p3.json
@@ -1,12 +1,12 @@
 {
   "name": "@vaadin/vaadin-combo-box",
-  "version": "5.4.11",
+  "version": "5.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@vaadin/vaadin-combo-box",
-      "version": "5.4.11",
+      "version": "5.5.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@polymer/iron-a11y-announcer": "^3.0.0",
@@ -20,7 +20,7 @@
         "@vaadin/vaadin-lumo-styles": "^1.1.1",
         "@vaadin/vaadin-material-styles": "^1.1.2",
         "@vaadin/vaadin-overlay": "^3.5.0",
-        "@vaadin/vaadin-text-field": "^2.8.0",
+        "@vaadin/vaadin-text-field": "^2.9.0",
         "@vaadin/vaadin-themable-mixin": "^1.6.1"
       },
       "devDependencies": {


### PR DESCRIPTION
## Description

This PR is part of preparation to release V14 minor versions including validation improvements.

## Type of change

- Version bump