### PR TITLE
fix: disable validation of internal text-field

### DIFF
--- a/src/vaadin-combo-box-light.html
+++ b/src/vaadin-combo-box-light.html
@@ -142,6 +142,17 @@ This program is available under Apache License Version 2.0, available at https:/
         return this.getRootNode().activeElement === this.inputElement;
       }
 
+      /**
+       * Returns true if the current input value satisfies all constraints (if any).
+       * @return {boolean}
+       */
+      checkValidity() {
+        if (this.inputElement && this.inputElement.validate) {
+          return this.inputElement.validate();
+        }
+        return super.checkValidity();
+      }
+
       /** @protected */
       connectedCallback() {
         super.connectedCallback();

--- a/src/vaadin-combo-box-mixin.html
+++ b/src/vaadin-combo-box-mixin.html
@@ -934,6 +934,7 @@ This program is available under Apache License Version 2.0, available at https:/
     /** @private */
     _detectAndDispatchChange() {
       if (this.value !== this._lastCommittedValue) {
+        this.validate();
         this.dispatchEvent(new CustomEvent('change', {bubbles: true}));
         this._lastCommittedValue = this.value;
       }
@@ -1098,6 +1099,7 @@ This program is available under Apache License Version 2.0, available at https:/
       }
       if (!this.readonly && !this._closeOnBlurIsPrevented) {
         this._closeOrCommit();
+        this.validate();
       }
     }
 
@@ -1164,8 +1166,8 @@ This program is available under Apache License Version 2.0, available at https:/
      * @return {boolean | undefined}
      */
     checkValidity() {
-      if (this.inputElement.validate) {
-        return this.inputElement.validate();
+      if (this.inputElement.checkValidity) {
+        return this.inputElement.checkValidity();
       }
     }
 

--- a/src/vaadin-combo-box.html
+++ b/src/vaadin-combo-box.html
@@ -387,6 +387,13 @@ This program is available under Apache License Version 2.0, available at https:/
         ready() {
           super.ready();
 
+          // Disable the internal text-field's validation to prevent it from overriding
+          // the invalid state that was propagated to the text-field from the combo-box.
+          this.inputElement.validate = () => {};
+          // Restore the internal text-field's invalid state in case
+          // it got overridden before the validation was disabled above.
+          this.inputElement.invalid = this.invalid;
+
           this._nativeInput = this.inputElement.focusElement;
           this._toggleElement = this.$.toggleButton;
           this._clearElement = this.inputElement.shadowRoot.querySelector('[part="clear-button"]');

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -234,7 +234,7 @@
       });
 
       it('should validate the paper-input element on checkValidity', () => {
-        const spy = sinon.spy(comboBox.inputElement, 'checkValidity');
+        const spy = sinon.spy(comboBox.inputElement, 'validate');
 
         comboBox.required = true;
         comboBox.value = 'foo';

--- a/test/vaadin-combo-box-light.html
+++ b/test/vaadin-combo-box-light.html
@@ -234,7 +234,7 @@
       });
 
       it('should validate the paper-input element on checkValidity', () => {
-        const spy = sinon.spy(comboBox.inputElement, 'validate');
+        const spy = sinon.spy(comboBox.inputElement, 'checkValidity');
 
         comboBox.required = true;
         comboBox.value = 'foo';
@@ -309,33 +309,33 @@
 
         it('should clear the selection when clicking on the clear button', () => {
           comboBox.open();
-    
+
           fire('click', clearButton);
-    
+
           expect(comboBox.value).to.eql('');
           expect(comboBox.$.overlay._selectedItem).to.be.null;
           expect(comboBox.selectedItem).to.be.null;
         });
-    
+
         it('should not close the dropdown after clearing a selection', () => {
           comboBox.open();
-    
+
           fire('click', clearButton);
-    
+
           expect(comboBox.opened).to.eql(true);
         });
-    
+
         it('should not open the dropdown after clearing a selection', () => {
           fire('click', clearButton);
-    
+
           expect(comboBox.opened).to.eql(false);
         });
-    
+
         it('should cancel click event to avoid input blur', () => {
           comboBox.open();
-    
+
           const event = fire('click', clearButton);
-    
+
           expect(event.defaultPrevented).to.eql(true);
         });
 

--- a/test/validation.html
+++ b/test/validation.html
@@ -81,8 +81,9 @@
   describe('basic', () => {
     let comboBox, validateSpy, changeSpy;
 
-    beforeEach(() => {
+    beforeEach(async() => {
       comboBox = fixture('combo-box');
+      await nextRender();
       validateSpy = sinon.spy(comboBox, 'validate');
       changeSpy = sinon.spy();
       comboBox.addEventListener('change', changeSpy);
@@ -95,21 +96,21 @@
     });
 
     it('should validate on blur', () => {
-      comboBox.focus();
-      comboBox.blur();
+      comboBox.inputElement.focus();
+      comboBox.inputElement.blur();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
     it('should validate on outside click', async() => {
-      comboBox.focus();
-      comboBox.click();
+      comboBox.inputElement.focus();
+      comboBox.inputElement.dispatchEvent(new CustomEvent('click', {composed: true, bubbles: true}));
       await nextRender();
       outsideClick();
       expect(validateSpy.calledOnce).to.be.true;
     });
 
     it('should validate before change event on Enter', () => {
-      comboBox.focus();
+      comboBox.inputElement.focus();
       comboBox.inputElement.value = 'foo';
       comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
       MockInteractions.pressAndReleaseKeyOn(comboBox.inputElement, 13, null, 'Enter');
@@ -121,7 +122,7 @@
     it('should validate before change event on clear button click', () => {
       comboBox.value = 'foo';
       validateSpy.reset();
-      comboBox.inputElement.$.clearButton.click();
+      comboBox.inputElement.$.clearButton.dispatchEvent(new CustomEvent('click', {composed: true, bubbles: true}));
       expect(validateSpy.calledOnce).to.be.true;
       expect(changeSpy.calledOnce).to.be.true;
       expect(changeSpy.calledAfter(validateSpy)).to.be.true;

--- a/test/validation.html
+++ b/test/validation.html
@@ -7,6 +7,7 @@
 
   <script src="../../web-component-tester/browser.js"></script>
   <script src='../../webcomponentsjs/webcomponents-lite.js'></script>
+  <link rel="import" href="../../iron-test-helpers/mock-interactions.html">
   <link rel="import" href="../src/vaadin-combo-box.html">
   <link rel="import" href="helpers.html">
   <link rel="import" href="../../test-fixture/test-fixture.html">
@@ -15,10 +16,32 @@
 <body>
   <test-fixture id="combo-box">
     <template>
-      <vaadin-combo-box></vaadin-combo-box>
+      <vaadin-combo-box items='["foo"]'></vaadin-combo-box>
     </template>
   </test-fixture>
+
+  <test-fixture id="combo-box-required">
+    <template>
+      <vaadin-combo-box required items='["foo"]'></vaadin-combo-box>
+    </template>
+  </test-fixture>
+
+  <test-fixture id="combo-box-required-value-invalid">
+    <template>
+      <vaadin-combo-box required items='["foo"]' value="foo" invalid></vaadin-combo-box>
+    </template>
+  </test-fixture>
+
   <script>
+  function outsideClick() {
+    // Move focus to body
+    document.body.tabIndex = 0;
+    document.body.focus();
+    document.body.tabIndex = -1;
+    // Outside click
+    document.body.click();
+  }
+
   describe('initial validation', () => {
     let comboBox;
     let validateSpy;
@@ -54,11 +77,54 @@
       expect(validateSpy.called).to.be.false;
     });
   });
+
   describe('basic', () => {
-    let comboBox;
+    let comboBox, validateSpy, changeSpy;
 
     beforeEach(() => {
       comboBox = fixture('combo-box');
+      validateSpy = sinon.spy(comboBox, 'validate');
+      changeSpy = sinon.spy();
+      comboBox.addEventListener('change', changeSpy);
+    });
+
+    it('should disable validation of internal text-field', () => {
+      comboBox.required = true;
+      comboBox.inputElement.validate();
+      expect(comboBox.inputElement.invalid).to.be.false;
+    });
+
+    it('should validate on blur', () => {
+      comboBox.focus();
+      comboBox.blur();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate on outside click', async() => {
+      comboBox.focus();
+      comboBox.click();
+      await nextRender();
+      outsideClick();
+      expect(validateSpy.calledOnce).to.be.true;
+    });
+
+    it('should validate before change event on Enter', () => {
+      comboBox.focus();
+      comboBox.inputElement.value = 'foo';
+      comboBox.inputElement.dispatchEvent(new CustomEvent('input'));
+      MockInteractions.pressAndReleaseKeyOn(comboBox.inputElement, 13, null, 'Enter');
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
+    });
+
+    it('should validate before change event on clear button click', () => {
+      comboBox.value = 'foo';
+      validateSpy.reset();
+      comboBox.inputElement.$.clearButton.click();
+      expect(validateSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledOnce).to.be.true;
+      expect(changeSpy.calledAfter(validateSpy)).to.be.true;
     });
 
     it('should fire a validated event on validation success', () => {
@@ -82,15 +148,47 @@
       expect(event.detail.valid).to.be.false;
     });
   });
+
+  describe('required', () => {
+    let comboBox;
+
+    beforeEach(async() => {
+      comboBox = fixture('combo-box-required');
+      await nextRender();
+    });
+
+    it('should pass validation with value', () => {
+      comboBox.value = 'foo';
+      expect(comboBox.checkValidity()).to.be.true;
+    });
+
+    it('should fail validation without value', () => {
+      expect(comboBox.checkValidity()).to.be.false;
+    });
+  });
+
+  describe('required + value + invalid', () => {
+    let comboBox;
+
+    beforeEach(async() => {
+      comboBox = fixture('combo-box-required-value-invalid');
+      await nextRender();
+    });
+
+    it('should propagate invalid state to internal text-field', () => {
+      expect(comboBox.inputElement.invalid).to.be.true;
+    });
+  });
+
   describe('invalid cannot be set to false', () => {
     let comboBox;
-  
+
     beforeEach(async() => {
       comboBox = fixture('combo-box');
       comboBox._shouldSetInvalid = (invalid) => invalid;
       await nextRender();
     });
-  
+
     it('should set invalid only when it is true', async() => {
       comboBox.required = true;
       comboBox.validate();

--- a/test/validation.html
+++ b/test/validation.html
@@ -95,17 +95,8 @@
       expect(comboBox.inputElement.invalid).to.be.false;
     });
 
-    it('should validate on blur', () => {
-      comboBox.inputElement.focus();
-      comboBox.inputElement.blur();
-      expect(validateSpy.calledOnce).to.be.true;
-    });
-
-    it('should validate on outside click', async() => {
-      comboBox.inputElement.focus();
-      comboBox.inputElement.dispatchEvent(new CustomEvent('click', {composed: true, bubbles: true}));
-      await nextRender();
-      outsideClick();
+    it('should validate on focusout', () => {
+      comboBox.inputElement.dispatchEvent(new CustomEvent('focusout', {bubbles: true, composed: true}));
       expect(validateSpy.calledOnce).to.be.true;
     });
 


### PR DESCRIPTION
## Description

The PR disables the internal text-field's validation so that it doesn't override the propagated invalid state.

Fixes https://github.com/vaadin/flow-components/issues/5409

> **Warning**
> Needs a cherry-pick to 14.10

## Type of change

- [x] Bugfix
